### PR TITLE
Add verified Opus Compose profile

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -93,6 +93,20 @@ Acceptance criteria:
 - Legacy dashboard modules are migrated in focused slices with build coverage.
 - Webpack remains a bundler detail, not the source of UI contracts.
 
+### Local Runtime
+
+The Opus runtime must have a supported local Compose mode so the application
+surface can be verified against its service dependencies before release.
+
+Acceptance criteria:
+
+- `BF_MODE=opus` resolves an Opus-specific Compose overlay.
+- The web runtime uses the existing Nginx and PHP service pattern.
+- Opus database configuration resolves to the local MySQL service through the
+  established `MYSQL_DB_*` environment contract.
+- Startup is reported successful only after a published application endpoint is
+  reachable.
+
 ## Known Gaps
 
 - Hoom currently emits Composer optimized-autoload warnings for many classes

--- a/docker/compose.opus.yml
+++ b/docker/compose.opus.yml
@@ -1,0 +1,30 @@
+services:
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "${BF_HTTP_PORT:-8080}:80"
+    volumes:
+      - ./:/app
+      - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - php
+    networks: [bf]
+
+  php:
+    build:
+      context: .
+      dockerfile: docker/php/Dockerfile
+      args:
+        INSTALL_XDEBUG: ${BF_INSTALL_XDEBUG:-false}
+    volumes:
+      - ./:/app
+      - ./docker/php/conf.d/xdebug.ini:/usr/local/etc/php/conf.d/99-xdebug.ini:ro
+    environment:
+      APP_ENV: local
+      PHP_IDE_CONFIG: "serverName=bf-local"
+      MYSQL_DB_HOST: ${BF_MYSQL_DB_HOST:-mysql}
+      MYSQL_DB_PORT: ${BF_MYSQL_DB_PORT:-3306}
+      MYSQL_DB_NAME: ${BF_MYSQL_DB_NAME:-app}
+      MYSQL_DB_USERNAME: ${BF_MYSQL_DB_USERNAME:-root}
+      MYSQL_DB_PASSWORD: ${BF_MYSQL_DB_PASSWORD:-root}
+    networks: [bf]

--- a/harness.json
+++ b/harness.json
@@ -1,0 +1,47 @@
+{
+  "version": "1.0",
+  "defaults": {
+    "laravel": { "mode": "laravel", "services": ["mysql", "redis"], "http_port": 8080 },
+    "opus":    { "mode": "opus",    "services": ["mysql", "redis"], "http_port": 8080 },
+    "frontend": { "mode": "frontend", "services": [],               "http_port": null },
+    "lib":     { "mode": "lib",     "services": [],                 "http_port": null },
+    "php-web": { "mode": "php-web", "services": ["mysql", "redis"], "http_port": 8080 },
+    "php-lib": { "mode": "php-lib", "services": [],                 "http_port": null }
+  },
+  "ports": {
+    "mysql": 33060,
+    "redis": 63790,
+    "memcached": 11211,
+    "mongo": 27018,
+    "postgres": 54320,
+    "elastic": 9200
+  },
+  "docker_env": {
+    "laravel": {
+      "DB_CONNECTION": "mysql",
+      "DB_HOST": "mysql",
+      "DB_PORT": "3306",
+      "DB_DATABASE": "app",
+      "DB_USERNAME": "root",
+      "DB_PASSWORD": "root"
+    },
+    "opus": {
+      "MYSQL_DB_HOST": "mysql",
+      "MYSQL_DB_PORT": "3306",
+      "MYSQL_DB_NAME": "app",
+      "MYSQL_DB_USERNAME": "root",
+      "MYSQL_DB_PASSWORD": "root"
+    },
+    "frontend": { },
+    "lib": { },
+    "php-web": {
+      "DB_CONNECTION": "mysql",
+      "DB_HOST": "mysql",
+      "DB_PORT": "3306",
+      "DB_DATABASE": "app",
+      "DB_USERNAME": "root",
+      "DB_PASSWORD": "root"
+    },
+    "php-lib": { }
+  }
+}

--- a/tests/Unit/Infrastructure/OpusComposeConfigurationTest.php
+++ b/tests/Unit/Infrastructure/OpusComposeConfigurationTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Infrastructure;
+
+use PHPUnit\Framework\TestCase;
+
+final class OpusComposeConfigurationTest extends TestCase
+{
+    public function testOpusModeHasAComposeOverlayForTheWebRuntime(): void
+    {
+        $composePath = $this->projectRoot() . DIRECTORY_SEPARATOR . 'docker' . DIRECTORY_SEPARATOR . 'compose.opus.yml';
+
+        $this->assertFileExists($composePath);
+
+        $compose = (string)file_get_contents($composePath);
+        $this->assertMatchesRegularExpression('/^services:/m', $compose);
+        $this->assertMatchesRegularExpression('/^  nginx:/m', $compose);
+        $this->assertMatchesRegularExpression('/^  php:/m', $compose);
+        $this->assertStringContainsString('MYSQL_DB_HOST: ${BF_MYSQL_DB_HOST:-mysql}', $compose);
+    }
+
+    public function testOpusHarnessDefaultsMatchTheLocalMysqlService(): void
+    {
+        $harness = json_decode(
+            (string)file_get_contents($this->projectRoot() . DIRECTORY_SEPARATOR . 'harness.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+
+        $this->assertSame('opus', $harness['defaults']['opus']['mode']);
+        $this->assertSame('mysql', $harness['docker_env']['opus']['MYSQL_DB_HOST']);
+        $this->assertSame('3306', $harness['docker_env']['opus']['MYSQL_DB_PORT']);
+        $this->assertSame('app', $harness['docker_env']['opus']['MYSQL_DB_NAME']);
+        $this->assertSame('root', $harness['docker_env']['opus']['MYSQL_DB_USERNAME']);
+        $this->assertSame('root', $harness['docker_env']['opus']['MYSQL_DB_PASSWORD']);
+    }
+
+    private function projectRoot(): string
+    {
+        return dirname(__DIR__, 3);
+    }
+}


### PR DESCRIPTION
## Intent

Provide a verified Compose profile for the Opus runtime so service configuration can be inspected consistently before an environment is started.

## User Stories And Acceptance Criteria

- A maintainer can select the `opus` runtime profile and receive the Nginx/PHP application surface with MySQL and Redis service fragments.
- The PHP service receives the established `MYSQL_DB_*` environment contract with service defaults.
- The profile is represented by a focused configuration test and documented runtime acceptance criteria.
- Configuration validation does not treat static profile inspection as application startup.

## Key Files Changed

- `docker/compose.opus.yml`
- `harness.json`
- `tests/Unit/Infrastructure/OpusComposeConfigurationTest.php`
- `SPEC.md`

## How To Test

```powershell
vendor\bin\phpunit.bat --do-not-cache-result tests\Unit\Infrastructure\OpusComposeConfigurationTest.php
vendor\bin\phpunit.bat --do-not-cache-result
```

## QA Checklist

- [x] Configuration tests pass.
- [x] Full PHPUnit suite passes.
- [x] Compose profile resolution succeeds with the base, Opus, MySQL, and Redis configuration.
- [x] No service container was started during configuration validation.

## Approval Conditions

Confirm that the MySQL defaults are appropriate for the runtime contract, then merge after the package-graph branch is accepted. This PR intentionally targets that branch to keep the change independently reviewable.