### PR TITLE
Document add-on authoring contract

### DIFF
--- a/ADDONS.md
+++ b/ADDONS.md
@@ -24,7 +24,7 @@ Keep these responsibilities separate:
 
 ## Package layout
 
-Use a conventional Composer package with a clear PSR-4 namespace. An installed package currently occupies `addons/<directory>/`, where `<directory>` is the manager's discovery key. The following layout includes the files consumed directly by the BlueCore manager; omit optional directories that do not serve the add-on's scope.
+Use a conventional Composer package with a clear PSR-4 namespace. An installed package currently occupies `addons/<directory>/`, where `<directory>` is the manager's discovery key. The following layout includes the files consumed directly by the BlueCore manager. Source and presentation directories may be omitted when they do not serve the add-on's scope, but both datasource directories are required even when empty.
 
 ```text
 composer.json
@@ -42,8 +42,8 @@ resource/
     templates/
     translations/
 datasources/
-    generator/
-    structure/
+    generator/     # required; may be empty
+    structure/     # required; may be empty
 tests/
 ```
 
@@ -60,7 +60,7 @@ The current manager scans each immediate directory under `addons/`. A discoverab
 
 The primary file is required for runtime loading and lifecycle hooks. Active add-ons are loaded from the stored add-on path plus `primary_file`. Installation and uninstallation load that same file and call `<name>_install()` or `<name>_uninstall()` when the corresponding function exists.
 
-Installation also configures datasource migrations from `datasources/structure/` and datasource generators from `datasources/generator/`. Keep those resources inside the add-on directory and make their work safe to repeat. Activation and deactivation persist add-on state; activation does not replace installation or dependency setup.
+Installation unconditionally configures datasource migrations from `datasources/structure/` and datasource generators from `datasources/generator/`. Include both directories even when the add-on has no migrations or generators. Keep those resources inside the add-on directory and make their work safe to repeat. Activation and deactivation persist add-on state; activation does not replace installation or dependency setup.
 
 Composer metadata remains the package and dependency boundary, but it is not currently the runtime discovery mechanism. A package installer or deployment process must place the package in the required `addons/<directory>/` layout without modifying application source files.
 

--- a/ADDONS.md
+++ b/ADDONS.md
@@ -8,7 +8,7 @@ Build an add-on around a durable capability. Its public API and configuration sh
 
 ## Package boundary
 
-An add-on must keep its implementation inside its own package. Do not patch Opus application files, write directly to platform add-on state, or depend on an installation path convention as part of the package contract.
+An add-on must keep its implementation inside its own package. Do not patch Opus application files or write directly to platform add-on state. The current BlueCore manager discovers installed add-ons through the application-owned `addons/` directory, so package installation must preserve the runtime layout described below.
 
 Use the platform add-on manager for lifecycle operations. In the current application, the manager owns install, activate, deactivate, uninstall, and active-package loading; add-on state is persisted through the BlueCore add-on query and repository contracts.
 
@@ -24,10 +24,12 @@ Keep these responsibilities separate:
 
 ## Package layout
 
-Use a conventional Composer package with a clear PSR-4 namespace. The following layout is a neutral starting point; omit directories that do not serve the add-on's scope.
+Use a conventional Composer package with a clear PSR-4 namespace. An installed package currently occupies `addons/<directory>/`, where `<directory>` is the manager's discovery key. The following layout includes the files consumed directly by the BlueCore manager; omit optional directories that do not serve the add-on's scope.
 
 ```text
 composer.json
+definition.json
+main.php
 README.md
 src/
     Application/
@@ -39,8 +41,27 @@ resource/
     migrations/
     templates/
     translations/
+datasources/
+    generator/
+    structure/
 tests/
 ```
+
+### Runtime discovery contract
+
+The current manager scans each immediate directory under `addons/`. A discoverable add-on must therefore provide:
+
+- `addons/<directory>/definition.json`, containing valid JSON metadata;
+- a nonempty `name`, or acceptance of `<directory>` as the default name;
+- an optional `description`;
+- an optional `libraries` array of Composer package names used to report explicit dependency commands; and
+- an optional `primary_file`, which defaults to `main.php`.
+
+The primary file is required for runtime loading and lifecycle hooks. Active add-ons are loaded from the stored add-on path plus `primary_file`. Installation and uninstallation load that same file and call `<name>_install()` or `<name>_uninstall()` when the corresponding function exists.
+
+Installation also configures datasource migrations from `datasources/structure/` and datasource generators from `datasources/generator/`. Keep those resources inside the add-on directory and make their work safe to repeat. Activation and deactivation persist add-on state; activation does not replace installation or dependency setup.
+
+Composer metadata remains the package and dependency boundary, but it is not currently the runtime discovery mechanism. A package installer or deployment process must place the package in the required `addons/<directory>/` layout without modifying application source files.
 
 `composer.json` should:
 
@@ -48,9 +69,9 @@ tests/
 - define PSR-4 autoloading for the package namespace;
 - require PHP 8.2 or later;
 - require compatible, published versions of Opus and the Blue Fission packages used directly by the add-on; and
-- declare the metadata required by the supported add-on discovery contract.
+- declare package metadata and direct dependencies independently of the runtime `definition.json` metadata.
 
-Treat package metadata as the discovery boundary. Do not rely on a package's local directory name, manually scan arbitrary directories, or modify the platform's Composer configuration from inside the add-on.
+Do not scan arbitrary directories or modify the platform's Composer configuration from inside the add-on. Treat the documented `addons/<directory>/definition.json` layout as a compatibility contract until the platform exposes a package-owned discovery registry.
 
 ## Coding and public standards
 
@@ -64,19 +85,19 @@ Lifecycle operations must be repeatable, observable, and safe to retry after a p
 
 ### Install
 
-Installation prepares package-owned resources and records only the state needed to make those resources usable. Schema setup, seed data, and configuration defaults must be idempotent. Installation must not silently activate unrelated capabilities.
+Installation prepares package-owned resources and records only the state needed to make those resources usable. The current manager runs datasource migrations, populates datasource state, invokes the optional `<name>_install()` hook, and records the add-on. Schema setup, seed data, configuration defaults, and hook behavior must be idempotent. Installation must not silently activate unrelated capabilities.
 
 ### Activate
 
-Activation registers the add-on's runtime behavior through the supported extension points. It should validate required configuration and fail with a clear, actionable error when prerequisites are unavailable. An activated package must not take ownership of global behavior outside its declared capability.
+Activation marks an installed add-on active so the manager can load its configured primary file during runtime bootstrap. Runtime registration performed by that file should validate required configuration and fail with a clear, actionable error when prerequisites are unavailable. An activated package must not take ownership of global behavior outside its declared capability.
 
 ### Deactivate
 
-Deactivation removes runtime registrations and stops work initiated by the add-on. It should preserve package data by default so that reactivation is safe. Any exception to that retention policy must be explicit in the package documentation and require deliberate operator action.
+Deactivation marks the add-on inactive so it is omitted from later active-add-on loading. Add-on runtime behavior should make shutdown and repeated bootstrap safe, and package data should be preserved by default so reactivation is safe. Any exception to that retention policy must be explicit in the package documentation and require deliberate operator action.
 
 ### Uninstall
 
-Uninstallation removes package registration and resources only after the add-on's data-retention policy has been applied. Destructive data removal must be explicit, documented, and independently confirmable; it must never be an implicit side effect of deactivation.
+Uninstallation invokes the optional `<name>_uninstall()` hook, removes package registration, and reverts the add-on's datasource migration batch. Destructive data removal must be explicit, documented, and independently confirmable; it must never be an implicit side effect of deactivation.
 
 ## Integrations and configuration
 

--- a/ADDONS.md
+++ b/ADDONS.md
@@ -53,6 +53,7 @@ The current manager scans each immediate directory under `addons/`. A discoverab
 
 - `addons/<directory>/definition.json`, containing valid JSON metadata;
 - a nonempty `name`, or acceptance of `<directory>` as the default name;
+- a `name` matching `[A-Za-z_][A-Za-z0-9_]*` when lifecycle hooks are provided, because the manager uses it verbatim as the PHP function-name stem;
 - an optional `description`;
 - an optional `libraries` array of Composer package names used to report explicit dependency commands; and
 - an optional `primary_file`, which defaults to `main.php`.

--- a/ADDONS.md
+++ b/ADDONS.md
@@ -1,0 +1,102 @@
+# Opus Add-On Authoring Guide
+
+## Purpose and scope
+
+An Opus add-on is a separately versioned package that contributes a coherent capability to an Opus installation. It owns its domain behavior, configuration, resources, and lifecycle work. Opus owns discovery, installation state, activation state, and the management surface that invokes those lifecycle operations.
+
+Build an add-on around a durable capability. Its public API and configuration should be useful wherever that capability is needed, rather than being shaped around one application, tenant, or workflow.
+
+## Package boundary
+
+An add-on must keep its implementation inside its own package. Do not patch Opus application files, write directly to platform add-on state, or depend on an installation path convention as part of the package contract.
+
+Use the platform add-on manager for lifecycle operations. In the current application, the manager owns install, activate, deactivate, uninstall, and active-package loading; add-on state is persisted through the BlueCore add-on query and repository contracts.
+
+Keep these responsibilities separate:
+
+| Area | Add-on responsibility | Platform responsibility |
+| --- | --- | --- |
+| Domain behavior | Services, models, policies, and package-owned APIs | Application composition and shared runtime facilities |
+| Metadata | Name, description, version compatibility, and discovery metadata | Discovery and installed/active state tracking |
+| Lifecycle | Idempotent resource setup and teardown behavior | Invoking lifecycle operations and loading active add-ons |
+| Configuration | Defaults, validation, and documented environment inputs | Supplying installation-level configuration facilities |
+| Resources | Routes, commands, templates, assets, migrations, and translations when applicable | Registering the add-on through the platform lifecycle |
+
+## Package layout
+
+Use a conventional Composer package with a clear PSR-4 namespace. The following layout is a neutral starting point; omit directories that do not serve the add-on's scope.
+
+```text
+composer.json
+README.md
+src/
+    Application/
+    Domain/
+    Infrastructure/
+    Presentation/
+config/
+resource/
+    migrations/
+    templates/
+    translations/
+tests/
+```
+
+`composer.json` should:
+
+- declare a stable, package-owned name and description;
+- define PSR-4 autoloading for the package namespace;
+- require compatible, published versions of Opus and the Blue Fission packages used directly by the add-on; and
+- declare the metadata required by the supported add-on discovery contract.
+
+Treat package metadata as the discovery boundary. Do not rely on a package's local directory name, manually scan arbitrary directories, or modify the platform's Composer configuration from inside the add-on.
+
+## Lifecycle design
+
+Lifecycle operations must be repeatable, observable, and safe to retry after a partial failure.
+
+### Install
+
+Installation prepares package-owned resources and records only the state needed to make those resources usable. Schema setup, seed data, and configuration defaults must be idempotent. Installation must not silently activate unrelated capabilities.
+
+### Activate
+
+Activation registers the add-on's runtime behavior through the supported extension points. It should validate required configuration and fail with a clear, actionable error when prerequisites are unavailable. An activated package must not take ownership of global behavior outside its declared capability.
+
+### Deactivate
+
+Deactivation removes runtime registrations and stops work initiated by the add-on. It should preserve package data by default so that reactivation is safe. Any exception to that retention policy must be explicit in the package documentation and require deliberate operator action.
+
+### Uninstall
+
+Uninstallation removes package registration and resources only after the add-on's data-retention policy has been applied. Destructive data removal must be explicit, documented, and independently confirmable; it must never be an implicit side effect of deactivation.
+
+## Integrations and configuration
+
+Use Blue Fission services, data objects, connections, CLI helpers, and behavior primitives where they fit the package boundary. Keep external service adapters behind package-owned interfaces and make optional integrations opt-in.
+
+Configuration should have documented defaults, validation, and a clear precedence order. Never commit credentials. Validate configuration at the boundary where it is consumed, and return errors that identify the missing or invalid setting without exposing secret values.
+
+Prefer explicit contracts for shared interfaces:
+
+- Define inputs, outputs, error conditions, and versioning expectations.
+- Keep HTTP routes, commands, events, and configuration keys namespaced to the add-on.
+- Add hooks only where a stable customization point is useful; document the value shape and test significant hook behavior.
+- Keep migrations forward-only and compatible with supported platform releases.
+
+## Testing and release checklist
+
+An add-on is ready for review when it demonstrates the lifecycle and package boundary in automated tests.
+
+- Unit-test package-owned domain behavior and configuration validation.
+- Verify a clean install and a repeated install produce the same usable state.
+- Verify activation exposes only the intended runtime behavior.
+- Verify deactivation removes runtime behavior without deleting retained data.
+- Verify uninstall follows the documented data policy.
+- Verify the package can be discovered and managed through the supported Opus add-on lifecycle.
+- Run `composer validate --strict` and the full package test suite before release.
+- Declare the tested Opus and direct dependency versions in the release notes.
+
+## Review questions
+
+Before accepting an add-on change, confirm that the capability belongs in a reusable package, the package has no direct platform-core edits, lifecycle actions are idempotent, configuration and persistence boundaries are explicit, and compatibility is documented. When an integration need is shared, extend the relevant upstream package through its public contract instead of embedding a one-off adapter in the add-on.

--- a/ADDONS.md
+++ b/ADDONS.md
@@ -60,7 +60,7 @@ The current manager scans each immediate directory under `addons/`. A discoverab
 - an optional `libraries` array of Composer package names used to report explicit dependency commands; and
 - an optional `primary_file`, which defaults to `main.php`.
 
-The primary file is required for runtime loading and lifecycle hooks. Active add-ons are loaded from the stored add-on path plus `primary_file`. Installation and uninstallation load that same file and call `<name>_install()` or `<name>_uninstall()` when the corresponding function exists.
+The primary file is required for runtime loading and lifecycle hooks. Active add-ons are loaded from the stored add-on path plus `primary_file`. Installation and uninstallation load that same file and call `<name>_install()` or `<name>_uninstall()` when the corresponding function exists. Declare both hook functions in the global namespace; the current manager performs an unqualified lookup and does not resolve namespaced functions.
 
 Installation configures datasource migrations from `datasources/structure/` and datasource generators from `datasources/generator/`; the current manager skips either area when its directory is absent. When present, each structure file must expose a discoverable class with `change()` and `revert()` methods. Each generator file must expose a discoverable class with `populate(bool $auto)`. A `RootSeeder.php` class may instead provide `seeders()` to select and order the remaining generator classes. Keep those resources inside the add-on directory and make their work safe to repeat. Activation and deactivation persist add-on state; activation does not replace installation or dependency setup.
 

--- a/ADDONS.md
+++ b/ADDONS.md
@@ -52,8 +52,8 @@ tests/
 The current manager scans each immediate directory under `addons/`. A discoverable add-on must therefore provide:
 
 - `addons/<directory>/definition.json`, containing valid JSON metadata;
-- a nonempty `name`, or acceptance of `<directory>` as the default name;
-- a `name` matching `[A-Za-z_][A-Za-z0-9_]*` when lifecycle hooks are provided, because the manager uses it verbatim as the PHP function-name stem;
+- an explicit, nonempty `name` that exactly matches `<directory>`, because current lifecycle APIs use the same value as both metadata identity and directory lookup key;
+- a `name` matching `[A-Za-z_][A-Za-z0-9_]*` when lifecycle hooks are provided, because the manager also uses it verbatim as the PHP function-name stem;
 - an optional `description`;
 - an optional `libraries` array of Composer package names used to report explicit dependency commands; and
 - an optional `primary_file`, which defaults to `main.php`.

--- a/ADDONS.md
+++ b/ADDONS.md
@@ -66,11 +66,12 @@ Installation configures datasource migrations from `datasources/structure/` and 
 
 The `libraries` list executes root-level Composer require commands during installation and remove commands during uninstallation. Because root requirements are shared by every add-on, removal must be coordinated so one package does not remove a dependency still owned by another.
 
-Composer metadata remains the package and dependency boundary, but it is not currently the runtime discovery mechanism. A package installer or deployment process must place the package in the required `addons/<directory>/` layout without modifying application source files.
+Composer metadata remains the package and dependency boundary, but it is not currently the runtime discovery mechanism. Install the package as an application-root Composer dependency with `type: opus-addon`. The locked BlueCore Composer plugin then places it under `addons/<package-name>/` while Composer registers the package's autoload metadata. Copying a package into `addons/` without Composer installation does not register its PSR-4 namespace.
 
 `composer.json` should:
 
 - declare a stable, package-owned name and description;
+- declare `type: opus-addon` so the BlueCore Composer plugin selects the add-on install path;
 - define PSR-4 autoloading for the package namespace;
 - require PHP 8.2 or later;
 - require compatible, published versions of Opus and the Blue Fission packages used directly by the add-on; and

--- a/ADDONS.md
+++ b/ADDONS.md
@@ -62,7 +62,7 @@ The current manager scans each immediate directory under `addons/`. A discoverab
 
 The primary file is required for runtime loading and lifecycle hooks. Active add-ons are loaded from the stored add-on path plus `primary_file`. Installation and uninstallation load that same file and call `<name>_install()` or `<name>_uninstall()` when the corresponding function exists. Declare both hook functions in the global namespace; the current manager performs an unqualified lookup and does not resolve namespaced functions.
 
-Installation configures datasource migrations from `datasources/structure/` and datasource generators from `datasources/generator/` unconditionally, so both directories must exist. Each structure file must expose a discoverable class with `change()` and `revert()` methods. Each generator file must expose a discoverable class with `populate()`. A `RootSeeder.php` class may instead provide `seeders()` to select and order the remaining generator classes. Keep those resources inside the add-on directory and make their work safe to repeat. Activation and deactivation persist add-on state; activation does not replace installation or dependency setup.
+Installation configures datasource migrations from `datasources/structure/` and datasource generators from `datasources/generator/` unconditionally, so both directories must exist. Each structure file must expose a global-namespace class with `change()` and `revert()` methods. Each generator file must expose a global-namespace class with `populate()`. A global-namespace `RootSeeder.php` class may instead provide `seeders()` to select and order the remaining generator classes. The locked loader resolves extracted short class names without their declared namespace. Keep those resources inside the add-on directory and make their work safe to repeat. Activation and deactivation persist add-on state; activation does not replace installation or dependency setup.
 
 The `libraries` list executes root-level Composer require commands during installation and remove commands during uninstallation. Because root requirements are shared by every add-on, removal must be coordinated so one package does not remove a dependency still owned by another.
 
@@ -122,7 +122,7 @@ Prefer explicit contracts for shared interfaces:
 An add-on is ready for review when it demonstrates the lifecycle and package boundary in automated tests.
 
 - Unit-test package-owned domain behavior and configuration validation.
-- Verify a clean install and a repeated install produce the same usable state.
+- Verify package-owned migrations, generators, and hooks are safe to repeat. The current manager may create duplicate registration records, so manager-level repeated installation is not an idempotency guarantee.
 - Verify activation exposes only the intended runtime behavior.
 - Verify deactivation removes runtime behavior without deleting retained data.
 - Verify uninstall follows the documented data policy.
@@ -132,4 +132,4 @@ An add-on is ready for review when it demonstrates the lifecycle and package bou
 
 ## Review questions
 
-Before accepting an add-on change, confirm that the capability belongs in a reusable package, the package has no direct platform-core edits, lifecycle actions are idempotent, configuration and persistence boundaries are explicit, and compatibility is documented. When an integration need is shared, extend the relevant upstream package through its public contract instead of embedding a one-off adapter in the add-on.
+Before accepting an add-on change, confirm that the capability belongs in a reusable package, the package has no direct platform-core edits, package-owned lifecycle resource actions are idempotent, configuration and persistence boundaries are explicit, and compatibility is documented. When an integration need is shared, extend the relevant upstream package through its public contract instead of embedding a one-off adapter in the add-on.

--- a/ADDONS.md
+++ b/ADDONS.md
@@ -24,7 +24,7 @@ Keep these responsibilities separate:
 
 ## Package layout
 
-Use a conventional Composer package with a clear PSR-4 namespace. An installed package currently occupies `addons/<directory>/`, where `<directory>` is the manager's discovery key. The following layout includes the files consumed directly by the BlueCore manager; omit optional directories that do not serve the add-on's scope.
+Use a conventional Composer package with a clear PSR-4 namespace. An installed package currently occupies `addons/<directory>/`, where `<directory>` is the manager's discovery key. The following layout includes the files consumed directly by the BlueCore manager. Both datasource directories are required even when empty.
 
 ```text
 composer.json
@@ -42,8 +42,8 @@ resource/
     templates/
     translations/
 datasources/
-    generator/
-    structure/
+    generator/     # required; may be empty
+    structure/     # required; may be empty
 tests/
 ```
 
@@ -57,14 +57,14 @@ The current manager scans each immediate directory under `addons/`. A discoverab
 - a nonempty `version` identifying the add-on release;
 - a nonempty `namespace` identifying the add-on's PHP namespace;
 - an optional `description`;
-- an optional `libraries` array of Composer package names used to report explicit dependency commands; and
-- an optional `primary_file`, which defaults to `main.php`.
+- an optional `libraries` array of Composer package names installed into or removed from the application root; and
+- a nonempty `primary_file`, normally `main.php`.
 
 The primary file is required for runtime loading and lifecycle hooks. Active add-ons are loaded from the stored add-on path plus `primary_file`. Installation and uninstallation load that same file and call `<name>_install()` or `<name>_uninstall()` when the corresponding function exists. Declare both hook functions in the global namespace; the current manager performs an unqualified lookup and does not resolve namespaced functions.
 
-Installation configures datasource migrations from `datasources/structure/` and datasource generators from `datasources/generator/`; the current manager skips either area when its directory is absent. When present, each structure file must expose a discoverable class with `change()` and `revert()` methods. Each generator file must expose a discoverable class with `populate(bool $auto)`. A `RootSeeder.php` class may instead provide `seeders()` to select and order the remaining generator classes. Keep those resources inside the add-on directory and make their work safe to repeat. Activation and deactivation persist add-on state; activation does not replace installation or dependency setup.
+Installation configures datasource migrations from `datasources/structure/` and datasource generators from `datasources/generator/` unconditionally, so both directories must exist. Each structure file must expose a discoverable class with `change()` and `revert()` methods. Each generator file must expose a discoverable class with `populate()`. A `RootSeeder.php` class may instead provide `seeders()` to select and order the remaining generator classes. Keep those resources inside the add-on directory and make their work safe to repeat. Activation and deactivation persist add-on state; activation does not replace installation or dependency setup.
 
-The `libraries` list produces root-level Composer require or remove commands. The manager reports those commands by default and executes them only when dependency mutation is explicitly enabled for install or uninstall. Because root requirements are shared by every add-on, removal must be coordinated so one package does not remove a dependency still owned by another.
+The `libraries` list executes root-level Composer require commands during installation and remove commands during uninstallation. Because root requirements are shared by every add-on, removal must be coordinated so one package does not remove a dependency still owned by another.
 
 Composer metadata remains the package and dependency boundary, but it is not currently the runtime discovery mechanism. A package installer or deployment process must place the package in the required `addons/<directory>/` layout without modifying application source files.
 

--- a/ADDONS.md
+++ b/ADDONS.md
@@ -24,7 +24,7 @@ Keep these responsibilities separate:
 
 ## Package layout
 
-Use a conventional Composer package with a clear PSR-4 namespace. An installed package currently occupies `addons/<directory>/`, where `<directory>` is the manager's discovery key. The following layout includes the files consumed directly by the BlueCore manager. Source and presentation directories may be omitted when they do not serve the add-on's scope, but both datasource directories are required even when empty.
+Use a conventional Composer package with a clear PSR-4 namespace. An installed package currently occupies `addons/<directory>/`, where `<directory>` is the manager's discovery key. The following layout includes the files consumed directly by the BlueCore manager; omit optional directories that do not serve the add-on's scope.
 
 ```text
 composer.json
@@ -42,8 +42,8 @@ resource/
     templates/
     translations/
 datasources/
-    generator/     # required; may be empty
-    structure/     # required; may be empty
+    generator/
+    structure/
 tests/
 ```
 
@@ -60,7 +60,9 @@ The current manager scans each immediate directory under `addons/`. A discoverab
 
 The primary file is required for runtime loading and lifecycle hooks. Active add-ons are loaded from the stored add-on path plus `primary_file`. Installation and uninstallation load that same file and call `<name>_install()` or `<name>_uninstall()` when the corresponding function exists.
 
-Installation unconditionally configures datasource migrations from `datasources/structure/` and datasource generators from `datasources/generator/`. Include both directories even when the add-on has no migrations or generators. Keep those resources inside the add-on directory and make their work safe to repeat. Activation and deactivation persist add-on state; activation does not replace installation or dependency setup.
+Installation configures datasource migrations from `datasources/structure/` and datasource generators from `datasources/generator/`; the current manager skips either area when its directory is absent. When present, each structure file must expose a discoverable class with `change()` and `revert()` methods. Each generator file must expose a discoverable class with `populate(bool $auto)`. A `RootSeeder.php` class may instead provide `seeders()` to select and order the remaining generator classes. Keep those resources inside the add-on directory and make their work safe to repeat. Activation and deactivation persist add-on state; activation does not replace installation or dependency setup.
+
+The `libraries` list produces root-level Composer require or remove commands. The manager reports those commands by default and executes them only when dependency mutation is explicitly enabled for install or uninstall. Because root requirements are shared by every add-on, removal must be coordinated so one package does not remove a dependency still owned by another.
 
 Composer metadata remains the package and dependency boundary, but it is not currently the runtime discovery mechanism. A package installer or deployment process must place the package in the required `addons/<directory>/` layout without modifying application source files.
 
@@ -111,7 +113,7 @@ Prefer explicit contracts for shared interfaces:
 - Define inputs, outputs, error conditions, and versioning expectations.
 - Keep HTTP routes, commands, events, and configuration keys namespaced to the add-on.
 - Add hooks only where a stable customization point is useful; document the value shape and test significant hook behavior.
-- Keep migrations forward-only and compatible with supported platform releases.
+- Keep migration ordering forward-moving, implement both `change()` and `revert()`, and remain compatible with supported platform releases.
 
 ## Testing and release checklist
 

--- a/ADDONS.md
+++ b/ADDONS.md
@@ -86,7 +86,7 @@ Public APIs, documentation, issues, and pull requests must remain package-owned 
 
 ## Lifecycle design
 
-Lifecycle operations must be repeatable, observable, and safe to retry after a partial failure.
+Package-owned lifecycle resource operations must be repeatable, observable, and safe to retry after a partial failure. The locked manager does not guarantee that its registration or orchestration steps are retryable.
 
 ### Install
 
@@ -102,7 +102,7 @@ Deactivation marks the add-on inactive so it is omitted from later active-add-on
 
 ### Uninstall
 
-Uninstallation invokes the optional `<name>_uninstall()` hook, removes package registration, and reverts the add-on's datasource migration batch. Destructive data removal must be explicit, documented, and independently confirmable; it must never be an implicit side effect of deactivation.
+Uninstallation invokes the optional `<name>_uninstall()` hook, removes package registration, and reverts the add-on's datasource migration batch. The locked manager deletes registration before dependency removal and migration reversion, so a failed manager-level uninstall is not safely retryable by the same add-on ID and requires operator reconciliation. Destructive data removal must be explicit, documented, and independently confirmable; it must never be an implicit side effect of deactivation.
 
 ## Integrations and configuration
 

--- a/ADDONS.md
+++ b/ADDONS.md
@@ -46,10 +46,17 @@ tests/
 
 - declare a stable, package-owned name and description;
 - define PSR-4 autoloading for the package namespace;
+- require PHP 8.2 or later;
 - require compatible, published versions of Opus and the Blue Fission packages used directly by the add-on; and
 - declare the metadata required by the supported add-on discovery contract.
 
 Treat package metadata as the discovery boundary. Do not rely on a package's local directory name, manually scan arbitrary directories, or modify the platform's Composer configuration from inside the add-on.
+
+## Coding and public standards
+
+Use strict types in new PHP files unless an established package boundary requires otherwise. Prefer DevElation primitives, behaviors, services, data objects, connections, and helpers where the Blue Fission ecosystem already owns the capability. Keep raw native operations at implementation or external-contract boundaries where wrapping would hide important semantics.
+
+Public APIs, documentation, issues, and pull requests must remain package-owned and collaborator-facing. Do not expose workstation paths, private coordination details, or scratch artifacts. Describe reusable acceptance criteria instead of justifying a capability around one consumer-specific request.
 
 ## Lifecycle design
 
@@ -94,7 +101,7 @@ An add-on is ready for review when it demonstrates the lifecycle and package bou
 - Verify deactivation removes runtime behavior without deleting retained data.
 - Verify uninstall follows the documented data policy.
 - Verify the package can be discovered and managed through the supported Opus add-on lifecycle.
-- Run `composer validate --strict` and the full package test suite before release.
+- Run `composer validate --strict` and `vendor/bin/phpunit --do-not-cache-result` before release.
 - Declare the tested Opus and direct dependency versions in the release notes.
 
 ## Review questions

--- a/ADDONS.md
+++ b/ADDONS.md
@@ -54,6 +54,8 @@ The current manager scans each immediate directory under `addons/`. A discoverab
 - `addons/<directory>/definition.json`, containing valid JSON metadata;
 - an explicit, nonempty `name` that exactly matches `<directory>`, because current lifecycle APIs use the same value as both metadata identity and directory lookup key;
 - a `name` matching `[A-Za-z_][A-Za-z0-9_]*` when lifecycle hooks are provided, because the manager also uses it verbatim as the PHP function-name stem;
+- a nonempty `version` identifying the add-on release;
+- a nonempty `namespace` identifying the add-on's PHP namespace;
 - an optional `description`;
 - an optional `libraries` array of Composer package names used to report explicit dependency commands; and
 - an optional `primary_file`, which defaults to `main.php`.

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ composer require bluefission/opus
 
 Opus's event management system allows you to hook into various events and filters, making it easy to extend and customize the framework's behavior.
 
-### Plugin System
+### Add-On System
 
-The plugin-based architecture allows for seamless feature additions and management. You can create plugins to extend the core functionality without modifying the core files directly.
+The add-on architecture allows for seamless feature additions and management without modifying core files directly. See the [add-on authoring guide](ADDONS.md) for the package boundary, lifecycle, structure, and validation expectations.
 
 ### AI Integration
 


### PR DESCRIPTION
Closes #22.

## Intent summary

Document the package-owned contract for authoring and reviewing Opus add-ons.

## User stories / acceptance criteria

- Authors can identify add-on and platform responsibilities.
- Authors have a neutral package layout and Composer metadata checklist.
- Lifecycle expectations cover install, activation, deactivation, and uninstall.
- The guide defines coding, public hygiene, configuration, integration, persistence, testing, and release expectations.

## Key files changed

- `ADDONS.md`
- `README.md`

## How to test

- `git diff --check`
- `composer validate --strict`

## QA checklist

- [x] No application behavior or dependency constraints changed.
- [x] Lifecycle guidance remains aligned with the public manager-owned operations.
- [x] The guide requires PHP 8.2, strict types, DevElation-first implementation, and exact test commands.
- [x] Documentation remains package-owned and consumer-neutral.

## Known caveats

- `composer validate --strict` reports the pre-existing non-SPDX `Exclusive` license warning.

## Approval conditions

- Confirm that the guide reflects the supported BlueCore add-on discovery metadata and lifecycle semantics before release.
