### PR TITLE
Publish root-safe Composer VCS registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,30 @@ Opus is a low-code/no-code platform aimed at democratizing AI technology. It all
 
 ## Installation
 
-To include Opus in your project, you can use Composer for package management:
+Composer only reads repository declarations from the root project. Most Blue
+Fission packages are source-distributed through GitHub VCS; DevElation is the
+only package in the supported graph resolved through Packagist.
+
+Start new applications from
+[`templates/composer/opus-root.json`](templates/composer/opus-root.json), or
+merge its `repositories` and `config.allow-plugins` sections into an existing
+root `composer.json` before requiring Opus:
 
 ```bash
 composer require bluefission/opus
 ```
+
+Do not add a DevElation VCS override. The root registry is required because
+Composer does not inherit repository definitions from Opus or other
+dependencies. After merging the registry, validate the application dependency
+graph without running package scripts:
+
+```bash
+composer update --no-scripts
+```
+
+Opus maintainers can verify that the template still covers the complete locked
+Blue Fission dependency graph with `composer audit:composer-vcs`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ only package in the supported graph resolved through Packagist.
 
 Start new applications from
 [`templates/composer/opus-root.json`](templates/composer/opus-root.json), or
-merge its `repositories` and `config.allow-plugins` sections into an existing
+merge its `repositories` and `config` sections into an existing
 root `composer.json` before requiring Opus:
 
 ```bash
@@ -42,6 +42,11 @@ graph without running package scripts:
 ```bash
 composer update --no-scripts
 ```
+
+Keep `config.use-github-api` set to `false` from the template. Composer then
+uses the declared Git repositories directly when GitHub API metadata is
+unavailable, while still retaining canonical GitHub source and distribution
+metadata in the lock.
 
 Opus maintainers can verify that the template still covers the complete locked
 Blue Fission dependency graph with `composer audit:composer-vcs`.

--- a/bin/audit-composer-vcs.php
+++ b/bin/audit-composer-vcs.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Opus\Tools\ComposerVcsAudit;
+
+$root = dirname(__DIR__);
+require_once $root . '/tools/ComposerVcsAudit.php';
+
+try {
+    $result = (new ComposerVcsAudit())->auditFiles(
+        $root . '/composer.json',
+        $root . '/composer.lock',
+        $root . '/templates/composer/opus-root.json'
+    );
+} catch (Throwable $error) {
+    fwrite(STDERR, '[fail] ' . $error->getMessage() . PHP_EOL);
+    exit(1);
+}
+
+foreach ($result['errors'] as $error) {
+    fwrite(STDERR, '[fail] ' . $error . PHP_EOL);
+}
+
+if ($result['errors'] !== []) {
+    exit(1);
+}
+
+echo '[ok] Blue Fission VCS registry covers '
+    . count($result['packages'])
+    . ' recursively required packages; DevElation remains Packagist-backed.'
+    . PHP_EOL;

--- a/composer.json
+++ b/composer.json
@@ -122,6 +122,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
+        "audit:composer-vcs": "@php bin/audit-composer-vcs.php",
         "post-root-package-install": [
             "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
         ]

--- a/composer.json
+++ b/composer.json
@@ -97,6 +97,7 @@
         "optimize-autoloader": true,
         "preferred-install": "dist",
         "sort-packages": true,
+        "use-github-api": false,
         "allow-plugins": {
             "composer/installers": true,
             "php-http/discovery": true,

--- a/templates/composer/opus-root.json
+++ b/templates/composer/opus-root.json
@@ -1,0 +1,77 @@
+{
+    "name": "bluefission/opus-application",
+    "description": "Root Composer template for an Opus application.",
+    "type": "project",
+    "repositories": {
+        "bluefission/opus": {
+            "type": "vcs",
+            "url": "https://github.com/BlueFissionTech/opus"
+        },
+        "bluefission/automata": {
+            "type": "vcs",
+            "url": "https://github.com/BlueFissionTech/automata"
+        },
+        "bluefission/bluecore": {
+            "type": "vcs",
+            "url": "https://github.com/BlueFissionTech/bluecore"
+        },
+        "bluefission/chronicler": {
+            "type": "vcs",
+            "url": "https://github.com/BlueFissionTech/chronicler"
+        },
+        "bluefission/wise": {
+            "type": "vcs",
+            "url": "https://github.com/BlueFissionTech/wise"
+        },
+        "bluefission/vibrato": {
+            "type": "vcs",
+            "url": "https://github.com/BlueFissionTech/vibrato"
+        },
+        "bluefission/presence": {
+            "type": "vcs",
+            "url": "https://github.com/BlueFissionTech/presence"
+        },
+        "bluefission/synematic": {
+            "type": "vcs",
+            "url": "https://github.com/BlueFissionTech/synematic"
+        },
+        "bluefission/annex-php-sdk": {
+            "type": "vcs",
+            "url": "https://github.com/BlueFissionTech/annex-php-sdk"
+        },
+        "bluefission/simpleclients": {
+            "type": "vcs",
+            "url": "https://github.com/BlueFissionTech/simpleclients"
+        },
+        "bluefission/synthetiq": {
+            "type": "vcs",
+            "url": "https://github.com/BlueFissionTech/synthetiq"
+        },
+        "bluefission/jenerator": {
+            "type": "vcs",
+            "url": "https://github.com/BlueFissionTech/jenerator"
+        },
+        "bluefission/opus-addon-hoom": {
+            "type": "vcs",
+            "url": "https://github.com/BlueFissionTech/opus-addon-hoom"
+        },
+        "bluefission/opus-addon-kapsle": {
+            "type": "vcs",
+            "url": "https://github.com/BlueFissionTech/opus-addon-kapsle"
+        }
+    },
+    "require": {
+        "php": "^8.2",
+        "bluefission/opus": "dev-main"
+    },
+    "config": {
+        "allow-plugins": {
+            "bluefission/bluecore": true,
+            "composer/installers": true,
+            "php-http/discovery": true
+        },
+        "sort-packages": true
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/templates/composer/opus-root.json
+++ b/templates/composer/opus-root.json
@@ -65,6 +65,7 @@
         "bluefission/opus": "dev-main"
     },
     "config": {
+        "use-github-api": false,
         "allow-plugins": {
             "bluefission/bluecore": true,
             "composer/installers": true,

--- a/tests.md
+++ b/tests.md
@@ -14,6 +14,17 @@ Run the runtime contract proof tests only:
 vendor\bin\phpunit --do-not-cache-result tests\Unit\RuntimeContractProofServiceTest.php tests\Unit\RuntimeContractManagerTest.php
 ```
 
+Validate the root-only GitHub VCS registry and recursive Blue Fission package
+graph:
+
+```powershell
+composer audit:composer-vcs
+```
+
+The audit intentionally permits `bluefission/develation` without a VCS entry;
+all other discovered `bluefission/*` packages must have canonical GitHub routes
+in both the Opus root and the consumer template.
+
 ## Runtime Contract Validation
 
 The default PHPUnit suite checks that the runtime contract files are present and

--- a/tests/Unit/ComposerVcsAuditTest.php
+++ b/tests/Unit/ComposerVcsAuditTest.php
@@ -69,10 +69,12 @@ class ComposerVcsAuditTest extends TestCase
         ];
         $composer = [
             'name' => 'bluefission/opus',
+            'config' => ['use-github-api' => false],
             'repositories' => [],
             'require' => [],
         ];
         $template = [
+            'config' => ['use-github-api' => false],
             'repositories' => ['bluefission/opus' => $repository],
         ];
 

--- a/tests/Unit/ComposerVcsAuditTest.php
+++ b/tests/Unit/ComposerVcsAuditTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Opus\Tools\ComposerVcsAudit;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../tools/ComposerVcsAudit.php';
+
+class ComposerVcsAuditTest extends TestCase
+{
+    public function testProjectRegistryCoversRecursiveSourcePackages(): void
+    {
+        $root = dirname(__DIR__, 2);
+        $result = (new ComposerVcsAudit())->auditFiles(
+            $root . '/composer.json',
+            $root . '/composer.lock',
+            $root . '/templates/composer/opus-root.json'
+        );
+
+        $this->assertSame([], $result['errors']);
+        $this->assertContains('bluefission/chronicler', $result['packages']);
+        $this->assertContains('bluefission/jenerator', $result['packages']);
+        $this->assertContains('bluefission/develation', $result['packages']);
+    }
+
+    public function testAuditReportsMissingRootRepositoryButAllowsPackagistDevelation(): void
+    {
+        $repository = [
+            'type' => 'vcs',
+            'url' => 'https://github.com/BlueFissionTech/automata',
+        ];
+        $composer = [
+            'repositories' => [],
+            'require' => ['bluefission/automata' => 'dev-master'],
+        ];
+        $lock = [
+            'packages' => [[
+                'name' => 'bluefission/automata',
+                'require' => ['bluefission/develation' => '^1.3'],
+                'source' => [
+                    'url' => 'https://github.com/BlueFissionTech/automata.git',
+                ],
+            ]],
+        ];
+        $template = [
+            'repositories' => ['bluefission/automata' => $repository],
+        ];
+
+        $result = (new ComposerVcsAudit())->audit($composer, $lock, $template);
+
+        $this->assertContains(
+            'Root composer.json is missing the canonical bluefission/automata repository.',
+            $result['errors']
+        );
+        $this->assertNotContains(
+            'Canonical consumer template is missing bluefission/develation.',
+            $result['errors']
+        );
+    }
+
+    public function testPackageDoesNotNeedToDeclareItselfAsARootRepository(): void
+    {
+        $repository = [
+            'type' => 'vcs',
+            'url' => 'https://github.com/BlueFissionTech/opus',
+        ];
+        $composer = [
+            'name' => 'bluefission/opus',
+            'repositories' => [],
+            'require' => [],
+        ];
+        $template = [
+            'repositories' => ['bluefission/opus' => $repository],
+        ];
+
+        $result = (new ComposerVcsAudit())->audit($composer, [], $template);
+
+        $this->assertSame([], $result['errors']);
+    }
+
+    public function testAuditRejectsNonGithubLockedSource(): void
+    {
+        $repository = [
+            'type' => 'vcs',
+            'url' => 'https://github.com/BlueFissionTech/wise',
+        ];
+        $composer = [
+            'name' => 'bluefission/opus',
+            'repositories' => ['bluefission/wise' => $repository],
+            'require' => ['bluefission/wise' => 'dev-main'],
+        ];
+        $lock = [
+            'packages' => [[
+                'name' => 'bluefission/wise',
+                'source' => ['url' => 'https://example.com/wise.git'],
+            ]],
+        ];
+        $template = [
+            'repositories' => ['bluefission/wise' => $repository],
+        ];
+
+        $result = (new ComposerVcsAudit())->audit($composer, $lock, $template);
+
+        $this->assertContains(
+            'Locked bluefission/wise does not resolve from its canonical GitHub source.',
+            $result['errors']
+        );
+    }
+}

--- a/tools/ComposerVcsAudit.php
+++ b/tools/ComposerVcsAudit.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Opus\Tools;
+
+use JsonException;
+use RuntimeException;
+
+final class ComposerVcsAudit
+{
+    private const PACKAGIST_PACKAGE = 'bluefission/develation';
+
+    /**
+     * @return array{errors: array<string>, packages: array<string>}
+     */
+    public function auditFiles(string $composerPath, string $lockPath, string $templatePath): array
+    {
+        return $this->audit(
+            $this->readJson($composerPath),
+            $this->readJson($lockPath),
+            $this->readJson($templatePath)
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $composer
+     * @param array<string, mixed> $lock
+     * @param array<string, mixed> $template
+     * @return array{errors: array<string>, packages: array<string>}
+     */
+    public function audit(array $composer, array $lock, array $template): array
+    {
+        $errors = [];
+        $rootRepositories = $this->repositoryMap($composer['repositories'] ?? []);
+        $templateRepositories = $this->repositoryMap($template['repositories'] ?? []);
+        $rootPackage = strtolower((string) ($composer['name'] ?? ''));
+
+        if (isset($rootRepositories[self::PACKAGIST_PACKAGE])) {
+            $errors[] = self::PACKAGIST_PACKAGE . ' must resolve through Packagist, not a root VCS override.';
+        }
+        if (isset($templateRepositories[self::PACKAGIST_PACKAGE])) {
+            $errors[] = self::PACKAGIST_PACKAGE . ' must not be present in the consumer VCS template.';
+        }
+
+        foreach ($templateRepositories as $package => $repository) {
+            $expectedUrl = 'https://github.com/BlueFissionTech/' . substr($package, strlen('bluefission/'));
+            if (($repository['type'] ?? null) !== 'vcs' || ($repository['url'] ?? null) !== $expectedUrl) {
+                $errors[] = "{$package} does not use its canonical GitHub VCS route.";
+            }
+
+            if (
+                $package !== $rootPackage
+                && !$this->repositoriesMatch($rootRepositories[$package] ?? null, $repository)
+            ) {
+                $errors[] = "Root composer.json is missing the canonical {$package} repository.";
+            }
+        }
+
+        $packages = $this->blueFissionRequirements($composer, $lock);
+        $lockedPackages = $this->lockedPackageMap($lock);
+        foreach ($packages as $package) {
+            if ($package === self::PACKAGIST_PACKAGE) {
+                continue;
+            }
+            if (!isset($templateRepositories[$package])) {
+                $errors[] = "Canonical consumer template is missing {$package}.";
+            }
+            if (!isset($rootRepositories[$package])) {
+                $errors[] = "Root composer.json is missing {$package}.";
+            }
+
+            $lockedSource = $lockedPackages[$package]['source']['url'] ?? null;
+            if ($this->packageFromRepositoryUrl($lockedSource) !== $package) {
+                $errors[] = "Locked {$package} does not resolve from its canonical GitHub source.";
+            }
+        }
+
+        return [
+            'errors' => array_values(array_unique($errors)),
+            'packages' => $packages,
+        ];
+    }
+
+    /**
+     * @param mixed $repositories
+     * @return array<string, array{type?: mixed, url?: mixed}>
+     */
+    private function repositoryMap($repositories): array
+    {
+        if (!is_array($repositories)) {
+            return [];
+        }
+
+        $mapped = [];
+        foreach ($repositories as $package => $repository) {
+            if (!is_array($repository)) {
+                continue;
+            }
+
+            if (is_string($package) && str_starts_with(strtolower($package), 'bluefission/')) {
+                $mapped[strtolower($package)] = $repository;
+                continue;
+            }
+
+            $repositoryPackage = $this->packageFromRepositoryUrl($repository['url'] ?? null);
+            if ($repositoryPackage !== null) {
+                $mapped[$repositoryPackage] = $repository;
+            }
+        }
+
+        ksort($mapped);
+        return $mapped;
+    }
+
+    /**
+     * @param array{type?: mixed, url?: mixed}|null $left
+     * @param array{type?: mixed, url?: mixed} $right
+     */
+    private function repositoriesMatch(?array $left, array $right): bool
+    {
+        if ($left === null || ($left['type'] ?? null) !== ($right['type'] ?? null)) {
+            return false;
+        }
+
+        $leftUrl = $left['url'] ?? null;
+        $rightUrl = $right['url'] ?? null;
+        return is_string($leftUrl)
+            && is_string($rightUrl)
+            && strtolower(rtrim($leftUrl, '/')) === strtolower(rtrim($rightUrl, '/'));
+    }
+
+    private function packageFromRepositoryUrl(mixed $url): ?string
+    {
+        if (!is_string($url)) {
+            return null;
+        }
+
+        if (preg_match('/^git@github\\.com:([^\\/]+)\\/(.+)$/i', $url, $matches) === 1) {
+            $owner = $matches[1];
+            $repository = $matches[2];
+        } else {
+            $host = parse_url($url, PHP_URL_HOST);
+            $path = parse_url($url, PHP_URL_PATH);
+            if (!is_string($host) || strtolower($host) !== 'github.com' || !is_string($path)) {
+                return null;
+            }
+
+            $segments = explode('/', trim($path, '/'));
+            if (count($segments) !== 2) {
+                return null;
+            }
+            [$owner, $repository] = $segments;
+        }
+
+        if (strtolower($owner) !== 'bluefissiontech') {
+            return null;
+        }
+
+        $repository = preg_replace('/\\.git$/i', '', $repository);
+        return is_string($repository) && $repository !== ''
+            ? 'bluefission/' . strtolower($repository)
+            : null;
+    }
+
+    /**
+     * @param array<string, mixed> $composer
+     * @param array<string, mixed> $lock
+     * @return array<string>
+     */
+    private function blueFissionRequirements(array $composer, array $lock): array
+    {
+        $locked = $this->lockedPackageMap($lock);
+
+        $queue = [];
+        foreach (array_keys($composer['require'] ?? []) as $package) {
+            if (is_string($package) && str_starts_with(strtolower($package), 'bluefission/')) {
+                $queue[] = strtolower($package);
+            }
+        }
+
+        $found = [];
+        while ($queue !== []) {
+            $package = array_shift($queue);
+            if (!is_string($package) || isset($found[$package])) {
+                continue;
+            }
+            $found[$package] = true;
+
+            foreach (array_keys($locked[$package]['require'] ?? []) as $dependency) {
+                if (is_string($dependency) && str_starts_with(strtolower($dependency), 'bluefission/')) {
+                    $queue[] = strtolower($dependency);
+                }
+            }
+        }
+
+        $packages = array_keys($found);
+        sort($packages);
+        return $packages;
+    }
+
+    /**
+     * @param array<string, mixed> $lock
+     * @return array<string, array<string, mixed>>
+     */
+    private function lockedPackageMap(array $lock): array
+    {
+        $locked = [];
+        foreach (array_merge($lock['packages'] ?? [], $lock['packages-dev'] ?? []) as $package) {
+            if (is_array($package) && isset($package['name']) && is_string($package['name'])) {
+                $locked[strtolower($package['name'])] = $package;
+            }
+        }
+
+        return $locked;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $contents = file_get_contents($path);
+        if ($contents === false) {
+            throw new RuntimeException("Unable to read {$path}.");
+        }
+
+        try {
+            $decoded = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $error) {
+            throw new RuntimeException("Invalid JSON in {$path}: {$error->getMessage()}", 0, $error);
+        }
+
+        if (!is_array($decoded)) {
+            throw new RuntimeException("Expected a JSON object in {$path}.");
+        }
+        return $decoded;
+    }
+}

--- a/tools/ComposerVcsAudit.php
+++ b/tools/ComposerVcsAudit.php
@@ -36,6 +36,13 @@ final class ComposerVcsAudit
         $templateRepositories = $this->repositoryMap($template['repositories'] ?? []);
         $rootPackage = strtolower((string) ($composer['name'] ?? ''));
 
+        if (($composer['config']['use-github-api'] ?? null) !== false) {
+            $errors[] = 'Root composer.json must enable direct Git fallback with config.use-github-api=false.';
+        }
+        if (($template['config']['use-github-api'] ?? null) !== false) {
+            $errors[] = 'Consumer template must enable direct Git fallback with config.use-github-api=false.';
+        }
+
         if (isset($rootRepositories[self::PACKAGIST_PACKAGE])) {
             $errors[] = self::PACKAGIST_PACKAGE . ' must resolve through Packagist, not a root VCS override.';
         }


### PR DESCRIPTION
Closes #24

## Intent

Publish the root-safe Composer installation contract that was pushed after PR #17 had already merged, and make direct Git resolution available when GitHub API metadata is unavailable.

## Changes

- Publish a canonical consumer-root template for all source-distributed Blue Fission packages.
- Keep DevElation Packagist-backed with no VCS override.
- Add a recursive audit for root/template coverage and locked GitHub source origins.
- Set `config.use-github-api=false` in the maintained root and consumer template.
- Document Composer's root-only repository behavior and migration procedure.

## Validation

- `php bin/audit-composer-vcs.php`: 14 recursive Blue Fission packages covered.
- `vendor/bin/phpunit --do-not-cache-result tests/Unit/ComposerVcsAuditTest.php tests/Unit/ComposerMetadataTest.php`: 4 tests, 8 assertions.
- `composer validate --strict --no-check-publish`: no lock errors; existing license and exact-alias warnings remain.
- `git diff --check`.
- A proxy-cleared Composer solve with GitHub API use disabled resolved BlueCore directly from Git and DevElation v1.3.40 from Packagist.

## Approval conditions

Confirm the package list, DevElation exception, direct-Git fallback, and copyable root template are suitable as the public installation contract.