### PR TITLE
Make fresh database initialization ordered and idempotent

### DIFF
--- a/app/Business/Services/EnvironmentLoader.php
+++ b/app/Business/Services/EnvironmentLoader.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Business\Services;
+
+final class EnvironmentLoader
+{
+    public static function import(string $file): void
+    {
+        $variables = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        if ($variables === false) {
+            return;
+        }
+
+        foreach ($variables as $variable) {
+            $variable = trim($variable);
+            if ($variable === '' || str_starts_with($variable, '#')) {
+                continue;
+            }
+
+            $separator = strpos($variable, '=');
+            if ($separator === false) {
+                continue;
+            }
+
+            $name = trim(substr($variable, 0, $separator));
+            if ($name === '') {
+                continue;
+            }
+
+            $value = trim(substr($variable, $separator + 1));
+            putenv($name . '=' . $value);
+            $_ENV[$name] = $value;
+        }
+    }
+}

--- a/app/Business/Services/EnvironmentLoader.php
+++ b/app/Business/Services/EnvironmentLoader.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Business\Services;
 
 final class EnvironmentLoader

--- a/app/Business/Services/ProjectPathResolver.php
+++ b/app/Business/Services/ProjectPathResolver.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Business\Services;
+
+final class ProjectPathResolver
+{
+    public static function resolve(
+        string $pathInProject,
+        string $applicationRoot,
+        string $projectRoot
+    ): string {
+        $applicationRoot = rtrim($applicationRoot, '/\\');
+        $projectRoot = rtrim($projectRoot, '/\\');
+        $pathInProject = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $pathInProject);
+
+        $candidate = $applicationRoot . DIRECTORY_SEPARATOR . $pathInProject;
+        $fallback = $projectRoot . DIRECTORY_SEPARATOR . $pathInProject;
+
+        if (file_exists($candidate)) {
+            return $candidate;
+        }
+
+        if (strpbrk($pathInProject, '*?[') !== false) {
+            $matches = glob($candidate);
+            if ($matches !== false && $matches !== []) {
+                return $candidate;
+            }
+        }
+
+        return $fallback;
+    }
+}

--- a/app/Business/Services/ProjectPathResolver.php
+++ b/app/Business/Services/ProjectPathResolver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Business\Services;
 
 final class ProjectPathResolver

--- a/common/helpers/functions.php
+++ b/common/helpers/functions.php
@@ -2,12 +2,7 @@
 
 if(!function_exists('import_env_vars')) {
 	function import_env_vars( $file ) {
-		$variables = file($file);
-		foreach ($variables as $var) {
-			putenv(trim($var));
-			list($name, $value) = explode("=", $var);
-			$_ENV[$name] = $value;
-		}
+		\App\Business\Services\EnvironmentLoader::import($file);
 	}
 }
 
@@ -26,16 +21,10 @@ if(!function_exists('env')) {
 if(!function_exists('resolve_path')) {
 	function resolve_path($pathInProject)
 	{
-	    $rootPath = rtrim(APP_ROOT, DIRECTORY_SEPARATOR);
-	    $projectPath = rtrim(PROJECT_ROOT, DIRECTORY_SEPARATOR);
-
-	    $candidate = $rootPath . DIRECTORY_SEPARATOR . $pathInProject;
-	    $fallback = $projectPath . DIRECTORY_SEPARATOR . $pathInProject;
-
-	    if (file_exists($candidate)) {
-	        return $candidate;
-	    }
-
-	    return $fallback;
+		return \App\Business\Services\ProjectPathResolver::resolve(
+			$pathInProject,
+			APP_ROOT,
+			PROJECT_ROOT
+		);
 	}
 }

--- a/common/helpers/settings.php
+++ b/common/helpers/settings.php
@@ -6,6 +6,9 @@ date_default_timezone_set('America/New_York');
 if (!defined("APP_ROOT") ){
 	define('APP_ROOT', dirname(dirname(dirname(__FILE__))).'/');	
 }
+if (!defined("OPUS_ROOT") ){
+	define('OPUS_ROOT', APP_ROOT);
+}
 if (!defined("PROJECT_ROOT") ){
 	define('PROJECT_ROOT', APP_ROOT . 'core');
 }

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
         "bluefission/automata": "v1.0.0-alpha.2 as dev-master",
         "bluefission/bluecore": "dev-main",
         "bluefission/chronicler": "v0.1.2-alpha as dev-main",
-        "bluefission/develation": "v1.3.40 as dev-master",
+        "bluefission/develation": "v1.3.41 as dev-master",
         "bluefission/opus-addon-hoom": "dev-main",
         "bluefission/opus-addon-kapsle": "dev-main",
         "bluefission/presence": "dev-main",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "afc4a37e5b91759a8ed6dc9b7dbc7201",
+    "content-hash": "713438fcdeb640cdab0fbfb08d429377",
     "packages": [
         {
             "name": "bluefission/annex-php-sdk",
@@ -133,12 +133,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/bluefissiontech/bluecore",
-                "reference": "b59f9e1c2b428f7bfb41948a0cf62f6d6a3b9814"
+                "reference": "8b1fae44d0c6f92028cc4a2cafd7ebec71d8618f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bluefissiontech/bluecore/zipball/b59f9e1c2b428f7bfb41948a0cf62f6d6a3b9814",
-                "reference": "b59f9e1c2b428f7bfb41948a0cf62f6d6a3b9814",
+                "url": "https://api.github.com/repos/bluefissiontech/bluecore/zipball/8b1fae44d0c6f92028cc4a2cafd7ebec71d8618f",
+                "reference": "8b1fae44d0c6f92028cc4a2cafd7ebec71d8618f",
                 "shasum": ""
             },
             "require": {
@@ -208,7 +208,7 @@
                 "framework",
                 "opus"
             ],
-            "time": "2026-08-01T13:22:23+00:00"
+            "time": "2026-08-07T20:09:59+00:00"
         },
         {
             "name": "bluefission/chronicler",
@@ -263,16 +263,16 @@
         },
         {
             "name": "bluefission/develation",
-            "version": "v1.3.40",
+            "version": "v1.3.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/BlueFissionTech/develation.git",
-                "reference": "7f53bad2a29533cb6dfb456d9b667899573e1bda"
+                "reference": "25bdd65152ef39a83524b30eb47cba2c061ded91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/BlueFissionTech/develation/zipball/7f53bad2a29533cb6dfb456d9b667899573e1bda",
-                "reference": "7f53bad2a29533cb6dfb456d9b667899573e1bda",
+                "url": "https://api.github.com/repos/BlueFissionTech/develation/zipball/25bdd65152ef39a83524b30eb47cba2c061ded91",
+                "reference": "25bdd65152ef39a83524b30eb47cba2c061ded91",
                 "shasum": ""
             },
             "require": {
@@ -331,7 +331,7 @@
                 "issues": "https://github.com/BlueFissionTech/develation/issues",
                 "source": "https://github.com/BlueFissionTech/develation"
             },
-            "time": "2026-08-07T00:37:47+00:00"
+            "time": "2026-08-07T19:31:33+00:00"
         },
         {
             "name": "bluefission/jenerator",
@@ -6469,7 +6469,7 @@
         },
         {
             "package": "bluefission/develation",
-            "version": "1.3.40.0",
+            "version": "1.3.41.0",
             "alias": "dev-master",
             "alias_normalized": "dev-master"
         }

--- a/datasources/generator/InitialUserData.php
+++ b/datasources/generator/InitialUserData.php
@@ -21,11 +21,15 @@ class InitialUserData extends Generator
 		$status = new CredentialStatusModel();
 		foreach ( $statuses as $label=>$name ) {
 			$status->clear();
-			$status->name = $name; //strtolower($label);
-			$status->label = $label;
-			$status->write();
+			$status->name = $name;
+			$status->read();
 
-			echo "Creating status: {$status->label} ";
+			if (!$status->id()) {
+				$status->label = $label;
+				$status->write();
+			}
+
+			echo "Ensuring status: {$label} ";
 			echo $status->status()."\n";
 		}
 
@@ -33,21 +37,33 @@ class InitialUserData extends Generator
 		$status->name = CredentialStatus::VERIFIED;
 		$status->read();
 
+		$user = new UserModel();
+		$credential = new CredentialModel();
+		$credential->username = 'admin';
+		$credential->read();
+
+		if ($credential->id()) {
+			echo "Admin credentials already exist.\n";
+			echo "Complete.\n";
+			return;
+		}
+
 		$password = env('DEFAULT_PASSWORD', Str::rand(null, 16, true));
 		if ( defined('STDIN') && !$auto ) {
 			$password = prompt_silent("Enter an admin password: ");
 		}
 
-		$user = new UserModel();
-		$credential = new CredentialModel();
-
-		$user->realname = 'System Admin';
 		$user->displayname = 'Admin';
-		$user->write();
-		echo "Creating Admin user: {$user->displayname} ";
+		$user->read();
+		if (!$user->id()) {
+			$user->realname = 'System Admin';
+			$user->displayname = 'Admin';
+			$user->write();
+		}
+		echo "Ensuring Admin user: {$user->displayname} ";
 		echo $user->status()."\n";
-		// $user->read();
 
+		$credential->clear();
 		$credential->username = 'admin';
 		$credential->password = $password;
 		$credential->is_primary = 1;

--- a/datasources/generator/InitialUserData.php
+++ b/datasources/generator/InitialUserData.php
@@ -53,13 +53,9 @@ class InitialUserData extends Generator
 			$password = prompt_silent("Enter an admin password: ");
 		}
 
+		$user->realname = 'System Admin';
 		$user->displayname = 'Admin';
-		$user->read();
-		if (!$user->id()) {
-			$user->realname = 'System Admin';
-			$user->displayname = 'Admin';
-			$user->write();
-		}
+		$user->write();
 		echo "Ensuring Admin user: {$user->displayname} ";
 		echo $user->status()."\n";
 

--- a/datasources/structure/2022_08_03_000000_scaffold_framework_tables.php
+++ b/datasources/structure/2022_08_03_000000_scaffold_framework_tables.php
@@ -10,7 +10,7 @@ class ScaffoldFrameworkTables extends Delta
 	public function change() {
 		Scaffold::create('migrations', function( Structure $entity ) {
 			$entity->incrementer('migration_id');
-			$entity->text('name')->unique();
+			$entity->text('name', 255)->unique();
 			$entity->text('batch');
 			$entity->numeric('iteration');
 			$entity->numeric('status')->default(0);

--- a/datasources/structure/20260807_expand_migration_name.php
+++ b/datasources/structure/20260807_expand_migration_name.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use BlueFission\BlueCore\Datasource\Delta;
 use BlueFission\Data\Storage\MySQL;
 

--- a/datasources/structure/20260807_expand_migration_name.php
+++ b/datasources/structure/20260807_expand_migration_name.php
@@ -1,0 +1,23 @@
+<?php
+
+use BlueFission\BlueCore\Datasource\Delta;
+use BlueFission\Data\Storage\MySQL;
+
+class ExpandMigrationName extends Delta
+{
+    public function change()
+    {
+        $database = new MySQL(['location' => null, 'name' => 'migrations']);
+        $database->activate();
+        $database->run('ALTER TABLE `migrations` MODIFY `name` VARCHAR(255) NOT NULL');
+
+        if ($database->status() !== MySQL::STATUS_SUCCESS) {
+            throw new RuntimeException($database->error());
+        }
+    }
+
+    public function revert()
+    {
+        // Migration names already persisted above 45 characters cannot be narrowed safely.
+    }
+}

--- a/terminal
+++ b/terminal
@@ -11,14 +11,14 @@ session_start();
 require 'common/helpers/functions.php';
 
 /**
- * Load the autoloader from the settings file.
- */
-require 'common/helpers/settings.php';
-
-/**
  * Include the autoloader for the dependencies.
  */
 require 'vendor/autoload.php';
+
+/**
+ * Load application settings after Composer can resolve shared helpers.
+ */
+require 'common/helpers/settings.php';
 
 // Loader utility for non-composer compatible scripts
 $loader = Loader::instance();

--- a/tests/Unit/ApplicationRootCompatibilityTest.php
+++ b/tests/Unit/ApplicationRootCompatibilityTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Unit;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/ApplicationRootCompatibilityTest.php
+++ b/tests/Unit/ApplicationRootCompatibilityTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+class ApplicationRootCompatibilityTest extends TestCase
+{
+    public function testLegacyRootAliasUsesTheApplicationRoot(): void
+    {
+        require_once dirname(__DIR__, 2) . '/common/helpers/settings.php';
+
+        $this->assertTrue(defined('APP_ROOT'));
+        $this->assertTrue(defined('OPUS_ROOT'));
+        $this->assertSame(APP_ROOT, OPUS_ROOT);
+    }
+}

--- a/tests/Unit/Business/Services/EnvironmentLoaderTest.php
+++ b/tests/Unit/Business/Services/EnvironmentLoaderTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Unit\Business\Services;
+
+use App\Business\Services\EnvironmentLoader;
+use PHPUnit\Framework\TestCase;
+
+class EnvironmentLoaderTest extends TestCase
+{
+    private string $file;
+
+    protected function setUp(): void
+    {
+        $this->file = tempnam(sys_get_temp_dir(), 'opus-env-');
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->file);
+        putenv('OPUS_TEST_FIRST');
+        putenv('OPUS_TEST_SECOND');
+        unset($_ENV['OPUS_TEST_FIRST'], $_ENV['OPUS_TEST_SECOND']);
+    }
+
+    public function testItImportsMixedLineEndingsAndValuesContainingEquals(): void
+    {
+        file_put_contents(
+            $this->file,
+            "OPUS_TEST_FIRST=alpha\r\nOPUS_TEST_SECOND=beta=gamma\n# ignored\r\n"
+        );
+
+        EnvironmentLoader::import($this->file);
+
+        $this->assertSame('alpha', getenv('OPUS_TEST_FIRST'));
+        $this->assertSame('alpha', $_ENV['OPUS_TEST_FIRST']);
+        $this->assertSame('beta=gamma', getenv('OPUS_TEST_SECOND'));
+        $this->assertSame('beta=gamma', $_ENV['OPUS_TEST_SECOND']);
+    }
+}

--- a/tests/Unit/Business/Services/EnvironmentLoaderTest.php
+++ b/tests/Unit/Business/Services/EnvironmentLoaderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Unit\Business\Services;
 
 use App\Business\Services\EnvironmentLoader;

--- a/tests/Unit/Business/Services/ProjectPathResolverTest.php
+++ b/tests/Unit/Business/Services/ProjectPathResolverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Unit\Business\Services;
 
 use App\Business\Services\ProjectPathResolver;

--- a/tests/Unit/Business/Services/ProjectPathResolverTest.php
+++ b/tests/Unit/Business/Services/ProjectPathResolverTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Unit\Business\Services;
+
+use App\Business\Services\ProjectPathResolver;
+use PHPUnit\Framework\TestCase;
+
+class ProjectPathResolverTest extends TestCase
+{
+    private string $applicationRoot;
+    private string $projectRoot;
+
+    protected function setUp(): void
+    {
+        $this->applicationRoot = dirname(__DIR__, 4);
+        $this->projectRoot = $this->applicationRoot . DIRECTORY_SEPARATOR . 'core';
+    }
+
+    public function testItResolvesAnExistingApplicationFile(): void
+    {
+        $this->assertSame(
+            $this->applicationRoot . DIRECTORY_SEPARATOR . 'common' . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'app.php',
+            ProjectPathResolver::resolve('common/config/app.php', $this->applicationRoot, $this->projectRoot)
+        );
+    }
+
+    public function testItResolvesMatchingWildcardsFromTheApplicationRoot(): void
+    {
+        $path = ProjectPathResolver::resolve(
+            'common/config/*.php',
+            $this->applicationRoot,
+            $this->projectRoot
+        );
+
+        $this->assertSame(
+            $this->applicationRoot . DIRECTORY_SEPARATOR . 'common' . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . '*.php',
+            $path
+        );
+        $this->assertNotEmpty(glob($path));
+    }
+
+    public function testItPreservesTheProjectFallbackForMissingPaths(): void
+    {
+        $this->assertSame(
+            $this->projectRoot . DIRECTORY_SEPARATOR . 'missing' . DIRECTORY_SEPARATOR . 'file.php',
+            ProjectPathResolver::resolve('missing/file.php', $this->applicationRoot, $this->projectRoot)
+        );
+    }
+}

--- a/tests/Unit/TerminalBootstrapOrderTest.php
+++ b/tests/Unit/TerminalBootstrapOrderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Unit;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/TerminalBootstrapOrderTest.php
+++ b/tests/Unit/TerminalBootstrapOrderTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+class TerminalBootstrapOrderTest extends TestCase
+{
+    public function testComposerLoadsBeforeApplicationSettings(): void
+    {
+        $terminal = file_get_contents(dirname(__DIR__, 2) . '/terminal');
+        $autoload = strpos($terminal, "require 'vendor/autoload.php';");
+        $settings = strpos($terminal, "require 'common/helpers/settings.php';");
+
+        $this->assertNotFalse($autoload);
+        $this->assertNotFalse($settings);
+        $this->assertLessThan($settings, $autoload);
+    }
+}


### PR DESCRIPTION
## Intent

Fixes #25 by making fresh PHP 8.2/MySQL initialization ordered and repeat-safe on the current released dependency baseline.

## User stories and acceptance criteria

- A clean installation loads Composer before settings need application services.
- Mixed CRLF/LF environment files import normalized values, including values containing `=`.
- Configuration wildcard paths resolve from the application root before the legacy fallback.
- Migration names up to 255 characters are persisted with uniqueness retained.
- Existing installations receive a widening migration without narrowing data on revert.
- Initial credential statuses and the administrator record are safe to populate repeatedly.
- DevElation resolves from Packagist at v1.3.41; current BlueCore main resolves from GitHub VCS.

CLI argument normalization remains isolated in #13, and bulk add-on activation remains isolated in #12.

## Key files changed

- `terminal`, `common/helpers/*`, and application path/environment services: bootstrap order and normalized configuration loading.
- `datasources/structure/*`: 255-character ledger definition and upgrade migration.
- `datasources/generator/InitialUserData.php`: repeat-safe status and administrator seeding.
- `composer.json` / `composer.lock`: DevElation v1.3.41 and BlueCore `8b1fae44d0c6f92028cc4a2cafd7ebec71d8618f`.
- Focused unit tests for bootstrap ordering, environment import, path resolution, and the root compatibility alias.

## How to test

```powershell
vendor\bin\phpunit.bat --do-not-cache-result
php examples\jenss\validate.php --parse-only
composer validate --strict --no-check-publish
git diff --check
```

MySQL 8 integration was run against a new isolated schema and then repeated:

- First delta recorded three distinct migrations at status `2`.
- Second delta performed no work.
- Two population passes remained at four distinct credential statuses, one user, and one administrator credential.
- A credential seeded from an explicitly supplied deployment password verified through the application security contract.
- No new application error-log entries were produced during the corrected cycles.

PHPUnit result: 36 tests, 103 assertions, two expected platform skips. All five configuration scripts pass parse-only validation.

The network-backed Composer advisory request could not complete because the host DNS resolver timed out on Packagist; CI must provide the advisory check. `composer validate` otherwise reports only the existing license and alias warnings.

## QA checklist

- [x] No vendor files modified.
- [x] No secrets or local paths committed.
- [x] Ratchet remains optional.
- [x] Fresh and repeated MySQL initialization verified.
- [x] Baseline PHPUnit and configuration validation pass.
- [ ] CI confirms the network-backed Composer advisory check.

## Approval conditions

- Confirm the widening migration and intentionally non-narrowing revert policy.
- Confirm the temporary application-root compatibility alias remains appropriate until Wise #22 lands.
- Confirm CI and review are green on the current head.
