### PR TITLE
Normalize database population arguments

### DIFF
--- a/app/Business/Console/DatabaseManager.php
+++ b/app/Business/Console/DatabaseManager.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Business\Console;
 
+use BlueFission\Arr;
 use BlueFission\Services\Service;
 use BlueFission\Behavioral\IDispatcher;
 use BlueFission\BlueCore\Business\Managers\DatasourceManager;
@@ -17,21 +18,19 @@ class DatabaseManager extends Service implements IDispatcher {
 
 	public function runMigrations()
 	{
-		$deltas = $this->_mgr->runMigrations();
+		$this->_mgr->runMigrations();
 	}
 
 	public function revertMigrations()
 	{
-		$deltas = $this->_mgr->revertMigrations();
+		$this->_mgr->revertMigrations();
 	}
 
 	public function populate( $args )
 	{
-		$arg = $args->context['data'] ?: null;
-		$auto = false;
-		if ($arg == 'auto') {
-			$auto = true;
-		}
-		$this->_mgr->populate($auto);
+		$data = Arr::getPath((array)($args->context ?? []), 'data', []);
+		$arguments = Arr::is($data) ? $data : [$data];
+
+		$this->_mgr->populate(Arr::contains($arguments, 'auto'));
 	}
 }

--- a/tests/Unit/Business/Console/DatabaseManagerTest.php
+++ b/tests/Unit/Business/Console/DatabaseManagerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Unit\Business\Console;
+
+use App\Business\Console\DatabaseManager;
+use BlueFission\Behavioral\Behaviors\Behavior;
+use BlueFission\BlueCore\Business\Managers\DatasourceManager;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseManagerTest extends TestCase
+{
+    public function testPopulateRecognizesAutoAsAPositionalArgument(): void
+    {
+        $datasource = $this->createMock(DatasourceManager::class);
+        $datasource->expects($this->once())
+            ->method('populate')
+            ->with(true);
+
+        $manager = new DatabaseManager($datasource);
+        $behavior = new Behavior('populate');
+        $behavior->context = ['data' => ['auto']];
+
+        $manager->populate($behavior);
+    }
+
+    public function testPopulateRemainsInteractiveWithoutAutoArgument(): void
+    {
+        $datasource = $this->createMock(DatasourceManager::class);
+        $datasource->expects($this->once())
+            ->method('populate')
+            ->with(false);
+
+        $manager = new DatabaseManager($datasource);
+        $behavior = new Behavior('populate');
+        $behavior->context = ['data' => []];
+
+        $manager->populate($behavior);
+    }
+}

--- a/tests/Unit/Business/Console/DatabaseManagerTest.php
+++ b/tests/Unit/Business/Console/DatabaseManagerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Unit\Business\Console;
 
 use App\Business\Console\DatabaseManager;


### PR DESCRIPTION
## Intent

Advance #13 with a bounded database-console slice: normalize positional command data before deciding whether population should run noninteractively.

## User stories and acceptance criteria

- `database populate auto` maps the positional `auto` argument to `DatasourceManager::populate(true)`.
- Population without `auto` preserves the interactive `false` contract.
- Missing or scalar behavior data is normalized without notices or loose array/string comparison.
- The console manager uses DevElation `Arr` helpers for behavior-context inspection.

This PR does not rename commands, change output envelopes, or absorb the remaining CLI inventory and presentation work in #13.

## Key files changed

- `app/Business/Console/DatabaseManager.php`: normalize positional data and remove unused migration result locals.
- `tests/Unit/Business/Console/DatabaseManagerTest.php`: prove automatic and interactive dispatch modes.

## How to test

```powershell
vendor\bin\phpunit.bat --do-not-cache-result tests\Unit\Business\Console\DatabaseManagerTest.php
vendor\bin\phpunit.bat --do-not-cache-result
php -l app\Business\Console\DatabaseManager.php
git diff --check
```

Focused result: 2 tests, 2 assertions. Full result on the branch baseline: 32 tests, 91 assertions, two expected platform skips.

End-to-end terminal execution should be repeated after #32 lands because that PR owns the independent initialization bootstrap required to reach this command on a clean installation.

## QA checklist

- [x] Public command names remain unchanged.
- [x] Interactive behavior remains the default.
- [x] No environment or persistence behavior changed outside argument mapping.
- [x] Focused and full PHPUnit suites pass.

## Approval conditions

- Confirm the behavior context may remain array or scalar for backward compatibility.
- Confirm review and CI are green on the current head.
- Repeat `database populate auto` after #32 is integrated.
