### PR TITLE
Add canonical add-on scaffold and validator

### DIFF
--- a/ADDONS.md
+++ b/ADDONS.md
@@ -24,28 +24,74 @@ Keep these responsibilities separate:
 
 ## Package layout
 
-Use a conventional Composer package with a clear PSR-4 namespace. An installed package currently occupies `addons/<directory>/`, where `<directory>` is the manager's discovery key. The following layout includes the files consumed directly by the BlueCore manager. Both datasource directories are required even when empty.
+Use a conventional Composer package with the PSR-4 namespace
+`AddOns\\<PackageName>\\` mapped to `logic/`. An installed package currently
+occupies `addons/<directory>/`, where `<directory>` is the manager's discovery
+key. Generate and validate the canonical structure with:
+
+```shell
+php bin/opus-addon.php generate sample_tools addons/sample_tools
+php bin/opus-addon.php validate addons/sample_tools
+```
+
+The output parent must already exist. Generation validates a temporary tree
+before publishing it and refuses to replace an existing destination.
+The discovery key uses lowercase snake case (`sample_tools`) because the locked
+lifecycle manager also uses it as the install/uninstall hook stem. Composer
+package slugs use the equivalent kebab case (`opus-addon-sample-tools`).
+Generated Composer metadata defaults to the valid `proprietary` license
+identifier. Replace it with the intended SPDX identifier only when the package
+has an approved open-source release license.
 
 ```text
 composer.json
 definition.json
 main.php
 README.md
-src/
-    Application/
+logic/
+    Business/
+        Http/
+        Managers/
+        Prompts/
     Domain/
-    Infrastructure/
-    Presentation/
-config/
+        Models/
+        Queries/
+        Repositories/
+        Values/
+    Registration/
+mapping/
+    api.php
+    app.php
+    console.php
+    default.php
+    menus.php
 resource/
-    migrations/
-    templates/
-    translations/
+    markup/
+        default.vibe
+    src/
 datasources/
     generator/     # required; may be empty
     structure/     # required; may be empty
 tests/
+phpunit.xml
 ```
+
+Mapping files return declarative values and must not require a fully booted
+application merely to load. In particular, `menus.php` returns an empty result
+when no navigation service is supplied so isolated contract validation does
+not invent a global navigation dependency. Invalid menu declarations remain a
+validation failure; optional capability handling is not an error-suppression
+boundary.
+
+Server-rendered templates use `.vibe`, canonical `{$value}` variables,
+executable `.vibe` includes, and named regions. Client-side Reactor bindings
+remain separate from the server template contract.
+
+Existing add-ons that map `AddOns\\<PackageName>\\` to the package root should
+migrate the mapping to `logic/` while correcting file namespaces. Run
+`composer dump-autoload -o` and the Opus validator before publishing that
+change. Keep compatibility shims explicit and temporary; the scaffold does not
+generate aliases for historical namespaces.
 
 ### Runtime discovery contract
 

--- a/ADDONS.md
+++ b/ADDONS.md
@@ -35,11 +35,13 @@ php bin/opus-addon.php validate addons/sample_tools
 ```
 
 The output parent must already exist. Generation validates a temporary tree,
-holds a target-specific publication lock, rechecks the destination, and then
-publishes the complete tree with one rename operation. Runtime discovery never
-sees a partially populated add-on, and concurrent scaffold writers cannot
-replace one another's output. When the destination is an immediate child of
-`addons/`, its directory name must exactly match the requested lifecycle key.
+holds a target-specific publication lock, and claims the destination with an
+atomic no-clobber directory creation. It moves validated contents first and
+publishes `definition.json` last as the BlueCore discovery marker. Runtime
+discovery therefore cannot load a partially populated add-on, and cooperating
+or independent writers cannot have their destination replaced. When the
+destination is an immediate child of `addons/`, its directory name must exactly
+match the requested lifecycle key.
 The lifecycle key and installer directory use lowercase snake case
 (`sample_tools`) because the locked lifecycle manager also uses the key as the
 install/uninstall hook stem. Composer package slugs are normalized separately

--- a/ADDONS.md
+++ b/ADDONS.md
@@ -34,11 +34,12 @@ php bin/opus-addon.php generate sample_tools addons/sample_tools
 php bin/opus-addon.php validate addons/sample_tools
 ```
 
-The output parent must already exist. Generation validates a temporary tree
-before publishing it, reserves the destination without replacement, and
-refuses to overwrite a destination created concurrently. When the destination
-is an immediate child of `addons/`, its directory name must exactly match the
-requested lifecycle key.
+The output parent must already exist. Generation validates a temporary tree,
+holds a target-specific publication lock, rechecks the destination, and then
+publishes the complete tree with one rename operation. Runtime discovery never
+sees a partially populated add-on, and concurrent scaffold writers cannot
+replace one another's output. When the destination is an immediate child of
+`addons/`, its directory name must exactly match the requested lifecycle key.
 The lifecycle key and installer directory use lowercase snake case
 (`sample_tools`) because the locked lifecycle manager also uses the key as the
 install/uninstall hook stem. Composer package slugs are normalized separately

--- a/ADDONS.md
+++ b/ADDONS.md
@@ -35,10 +35,15 @@ php bin/opus-addon.php validate addons/sample_tools
 ```
 
 The output parent must already exist. Generation validates a temporary tree
-before publishing it and refuses to replace an existing destination.
-The discovery key uses lowercase snake case (`sample_tools`) because the locked
-lifecycle manager also uses it as the install/uninstall hook stem. Composer
-package slugs use the equivalent kebab case (`opus-addon-sample-tools`).
+before publishing it, reserves the destination without replacement, and
+refuses to overwrite a destination created concurrently. When the destination
+is an immediate child of `addons/`, its directory name must exactly match the
+requested lifecycle key.
+The lifecycle key and installer directory use lowercase snake case
+(`sample_tools`) because the locked lifecycle manager also uses the key as the
+install/uninstall hook stem. Composer package slugs are normalized separately
+to kebab case (`opus-addon-sample-tools`). Their current values correspond, but
+they are distinct package and runtime identities.
 Generated Composer metadata defaults to the valid `proprietary` license
 identifier. Replace it with the intended SPDX identifier only when the package
 has an approved open-source release license.
@@ -76,12 +81,23 @@ tests/
 phpunit.xml
 ```
 
-Mapping files return declarative values and must not require a fully booted
-application merely to load. In particular, `menus.php` returns an empty result
-when no navigation service is supplied so isolated contract validation does
-not invent a global navigation dependency. Invalid menu declarations remain a
-validation failure; optional capability handling is not an error-suppression
-boundary.
+Mapping files use one of two contracts. The generated form contains an optional
+strict-types declaration followed by a single returned array. Existing packages
+may instead import `BlueFission\Services\Mapping` and contain only
+`Mapping::add()` or `Mapping::crud()` registrations with fluent mapping policy
+calls. Arbitrary top-level assignments, includes, and function calls remain
+invalid. In particular, `menus.php` returns an empty result when no navigation
+service is supplied so isolated contract validation does not invent a global
+navigation dependency. Invalid menu declarations remain a validation failure;
+optional capability handling is not an error-suppression boundary.
+
+`definition.json` declares registration behavior through a package-owned class
+and a primary-file factory. The validator derives the registration file from
+the declared class instead of requiring a fixed filename. Theme entries declare
+a directory beneath `resource/markup/` and a `.vibe` entrypoint; this supports
+both a single-file default and directory-backed themes. Generated test bootstrap
+code first resolves a package-local Composer autoloader and then an application-
+root autoloader for packages installed under `addons/`.
 
 Server-rendered templates use `.vibe`, canonical `{$value}` variables,
 executable `.vibe` includes, and named regions. Client-side Reactor bindings
@@ -92,6 +108,14 @@ migrate the mapping to `logic/` while correcting file namespaces. Run
 `composer dump-autoload -o` and the Opus validator before publishing that
 change. Keep compatibility shims explicit and temporary; the scaffold does not
 generate aliases for historical namespaces.
+
+Canonical namespace casing is `AddOns\\`. Packages using historical `Addons\\`
+casing must update Composer PSR-4 metadata, declarations, and references in the
+same compatibility release; do not maintain permanent case-only aliases.
+Domain value objects belong in `logic/Domain/Values`. Packages using
+`Domain/Value` or `Domain/ValueObjects` should move the files and update their
+namespaces together, with a temporary explicit forwarding class only when a
+published API requires a migration window.
 
 ### Runtime discovery contract
 

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -531,7 +531,22 @@ final class AddOnContractValidator extends Service
 
     private function factoryClassImportName(Arr $tokens, string $class): ?string
     {
+        $structuralDepth = 0;
         foreach ($tokens as $index => $token) {
+            if ($token === '{') {
+                $structuralDepth++;
+                continue;
+            }
+            if ($token === '}') {
+                $structuralDepth--;
+                continue;
+            }
+            if ($structuralDepth !== 0) {
+                continue;
+            }
+            if ($this->tokenIs($token, T_RETURN)) {
+                break;
+            }
             if ($this->tokenIs($token, T_USE)
                 && $this->factoryClassTokenIs($tokens->get($index + 1), $class, null)
             ) {
@@ -696,7 +711,11 @@ final class AddOnContractValidator extends Service
                 && $arrowClosureLevels->isNotEmpty()
                 && $arrowClosureLevels->get($arrowClosureLevels->count() - 1) === $delimiters->count()
             ) {
-                $arrowClosureLevels->pop();
+                do {
+                    $arrowClosureLevels->pop();
+                } while ($arrowClosureLevels->isNotEmpty()
+                    && $arrowClosureLevels->get($arrowClosureLevels->count() - 1) === $delimiters->count()
+                );
             }
             if ($callableBodyDepth === 0
                 && $pendingCallableBodies === 0
@@ -719,10 +738,14 @@ final class AddOnContractValidator extends Service
                 continue;
             }
             if ($closing->hasKey($token)) {
-                if ($arrowClosureLevels->isNotEmpty()
+                $closedArrow = false;
+                while ($arrowClosureLevels->isNotEmpty()
                     && $arrowClosureLevels->get($arrowClosureLevels->count() - 1) === $delimiters->count()
                 ) {
                     $arrowClosureLevels->pop();
+                    $closedArrow = true;
+                }
+                if ($closedArrow) {
                     $closedCallableExpression = $arrowClosureLevels->isEmpty();
                 }
                 if ($token === '}' && $callableBodyDepth > 0) {

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -467,6 +467,7 @@ final class AddOnContractValidator extends Service
         $waitingForCallableBody = false;
         $arrowClosureLevel = null;
         $closedCallableExpression = false;
+        $previousToken = null;
         $disallowed = Arr::make([
             T_EVAL,
             T_EXIT,
@@ -488,6 +489,14 @@ final class AddOnContractValidator extends Service
             if ($closedCallableExpression && $token === '(') {
                 return false;
             }
+            if ($callableBodyDepth === 0
+                && !$waitingForCallableBody
+                && $arrowClosureLevel === null
+                && $token === '('
+                && $this->tokenCanBeInvoked($previousToken)
+            ) {
+                return false;
+            }
             if ($closedCallableExpression && $token !== ')') {
                 $closedCallableExpression = false;
             }
@@ -505,6 +514,7 @@ final class AddOnContractValidator extends Service
                 ) {
                     return false;
                 }
+                $previousToken = $token;
                 continue;
             }
             if ($token === ',' && $arrowClosureLevel === $delimiters->count()) {
@@ -520,6 +530,7 @@ final class AddOnContractValidator extends Service
                         $callableBodyDepth++;
                     }
                 }
+                $previousToken = $token;
                 continue;
             }
             if ($closing->hasKey($token)) {
@@ -537,6 +548,7 @@ final class AddOnContractValidator extends Service
                     return false;
                 }
             }
+            $previousToken = $token;
         }
 
         if ($waitingForCallableBody
@@ -747,6 +759,12 @@ final class AddOnContractValidator extends Service
             T_NAME_RELATIVE,
             T_STRING,
         ]);
+    }
+
+    private function tokenCanBeInvoked($token): bool
+    {
+        return $this->tokenIs($token, T_CONSTANT_ENCAPSED_STRING)
+            || Arr::make([']', ')', '}'])->has($token, true);
     }
 
     private function files(string $root, string $extension): array

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -323,10 +323,7 @@ final class AddOnContractValidator extends Service
             if (Str::is($source)) {
                 try {
                     $tokens = token_get_all($source, TOKEN_PARSE);
-                    $declared = Str::make($this->declaredNamespace($tokens))
-                        ->append('\\')
-                        ->append($this->declaredClass($tokens))
-                        ->val();
+                    $declared = $this->declaredClassName($tokens);
                     if ($declared !== $class) {
                         $errors->push($this->problem(
                             'registration_class',
@@ -411,12 +408,15 @@ final class AddOnContractValidator extends Service
         });
     }
 
-    private function declaredClass(array $tokens): string
+    private function declaredClassName(array $tokens): string
     {
         $tokens = $this->significantTokens($tokens);
         $structuralDepth = 0;
         $namespaceDepth = 0;
         $namespacePending = false;
+        $namespace = Str::make('');
+        $pendingNamespace = Str::make('');
+        $namespaceTokens = Arr::make([T_STRING, T_NAME_QUALIFIED, T_NS_SEPARATOR]);
         $interpolationDepth = 0;
         $parenthesisDepth = 0;
         $alternativeScopeDepth = 0;
@@ -449,6 +449,12 @@ final class AddOnContractValidator extends Service
                 }
                 if ($type === T_NAMESPACE) {
                     $namespacePending = true;
+                    $pendingNamespace = Str::make('');
+                    $previousToken = $token;
+                    continue;
+                }
+                if ($namespacePending && $namespaceTokens->has($type, true)) {
+                    $pendingNamespace->append((string) Arr::make($token)->get(1));
                     $previousToken = $token;
                     continue;
                 }
@@ -474,9 +480,14 @@ final class AddOnContractValidator extends Service
 
                 $name = $tokens->shift();
 
-                return $this->tokenIs($name, T_STRING)
-                    ? (string) Arr::make($name)->get(1)
-                    : '';
+                if (!$this->tokenIs($name, T_STRING)) {
+                    return '';
+                }
+
+                return Str::make($namespace->val())
+                    ->append($namespace->isEmpty() ? '' : '\\')
+                    ->append((string) Arr::make($name)->get(1))
+                    ->val();
             }
             if ($token === '}' && $interpolationDepth > 0) {
                 $interpolationDepth--;
@@ -484,6 +495,7 @@ final class AddOnContractValidator extends Service
                 continue;
             }
             if ($namespacePending && ($token === ';' || $token === '{')) {
+                $namespace = $pendingNamespace;
                 if ($token === '{') {
                     $structuralDepth++;
                 }
@@ -823,8 +835,27 @@ final class AddOnContractValidator extends Service
                 } elseif ($type === T_FUNCTION) {
                     $pendingCallableBodies++;
                 } elseif ($type === T_FN && $callableBodyDepth === 0) {
-                    $arrowClosureLevels->push($delimiters->count());
-                } elseif ($callableBodyDepth === 0
+                    $arrowClosureLevels->push([
+                        'level' => $delimiters->count(),
+                        'started' => false,
+                    ]);
+                } elseif ($type === T_DOUBLE_ARROW && $arrowClosureLevels->isNotEmpty()) {
+                    $index = $arrowClosureLevels->count() - 1;
+                    $arrow = Arr::make($arrowClosureLevels->get($index));
+                    if (!$arrow->get('started')) {
+                        $arrow->set('started', true);
+                        $arrowClosureLevels->set($index, $arrow->val());
+                        $previousToken = $token;
+                        continue;
+                    }
+                    while ($arrowClosureLevels->isNotEmpty()
+                        && Arr::make($arrowClosureLevels->get($arrowClosureLevels->count() - 1))
+                            ->get('level') === $delimiters->count()
+                    ) {
+                        $arrowClosureLevels->pop();
+                    }
+                }
+                if ($callableBodyDepth === 0
                     && $pendingCallableBodies === 0
                     && $arrowClosureLevels->isEmpty()
                     && !$this->isSafeDeclarativeToken($token, $previousToken, $tokens)
@@ -841,12 +872,14 @@ final class AddOnContractValidator extends Service
             }
             if ($token === ','
                 && $arrowClosureLevels->isNotEmpty()
-                && $arrowClosureLevels->get($arrowClosureLevels->count() - 1) === $delimiters->count()
+                && Arr::make($arrowClosureLevels->get($arrowClosureLevels->count() - 1))
+                    ->get('level') === $delimiters->count()
             ) {
                 do {
                     $arrowClosureLevels->pop();
                 } while ($arrowClosureLevels->isNotEmpty()
-                    && $arrowClosureLevels->get($arrowClosureLevels->count() - 1) === $delimiters->count()
+                    && Arr::make($arrowClosureLevels->get($arrowClosureLevels->count() - 1))
+                        ->get('level') === $delimiters->count()
                 );
             }
             if ($callableBodyDepth === 0
@@ -872,7 +905,8 @@ final class AddOnContractValidator extends Service
             if ($closing->hasKey($token)) {
                 $closedArrow = false;
                 while ($arrowClosureLevels->isNotEmpty()
-                    && $arrowClosureLevels->get($arrowClosureLevels->count() - 1) === $delimiters->count()
+                    && Arr::make($arrowClosureLevels->get($arrowClosureLevels->count() - 1))
+                        ->get('level') === $delimiters->count()
                 ) {
                     $arrowClosureLevels->pop();
                     $closedArrow = true;

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -450,10 +450,78 @@ final class AddOnContractValidator extends Service
                 $tokens->shift();
             }
 
-            return $this->tokenIsOneOf($tokens->shift(), [T_FN, T_FUNCTION]);
+            $callable = $tokens->shift();
+            if ($this->tokenIs($callable, T_FN)) {
+                return $this->consumeArrowFactory($tokens);
+            }
+            if ($this->tokenIs($callable, T_FUNCTION)) {
+                return $this->consumeTraditionalFactory($tokens);
+            }
+
+            return false;
         }
 
         return false;
+    }
+
+    private function consumeArrowFactory(Arr $tokens): bool
+    {
+        $delimiters = Arr::make([]);
+        $pairs = Arr::make(['(' => ')', '[' => ']', '{' => '}']);
+        $closings = Arr::make([')' => true, ']' => true, '}' => true]);
+        while (!$tokens->isEmpty()) {
+            $token = $tokens->shift();
+            if (Arr::is($token)) {
+                continue;
+            }
+            if ($pairs->hasKey($token)) {
+                $delimiters->push($pairs->get($token));
+                continue;
+            }
+            if ($closings->hasKey($token)) {
+                if ($delimiters->isEmpty() || $token !== $delimiters->pop()) {
+                    return false;
+                }
+                continue;
+            }
+            if ($token === ';' && $delimiters->isEmpty()) {
+                return $this->factoryRemainderIsEmpty($tokens);
+            }
+        }
+
+        return false;
+    }
+
+    private function consumeTraditionalFactory(Arr $tokens): bool
+    {
+        $bodyDepth = 0;
+        $bodyStarted = false;
+        while (!$tokens->isEmpty()) {
+            $token = $tokens->shift();
+            if ($token === '{') {
+                $bodyStarted = true;
+                $bodyDepth++;
+                continue;
+            }
+            if ($token === '}' && $bodyStarted) {
+                $bodyDepth--;
+                if ($bodyDepth === 0) {
+                    return $tokens->shift() === ';'
+                        && $this->factoryRemainderIsEmpty($tokens);
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function factoryRemainderIsEmpty(Arr $tokens): bool
+    {
+        if ($this->tokenIs($tokens->get(0), T_CLOSE_TAG)) {
+            $tokens->shift();
+        }
+
+        return $tokens->isEmpty();
     }
 
     private function isSupportedMapping(array $tokens): bool
@@ -650,44 +718,8 @@ final class AddOnContractValidator extends Service
             return false;
         }
 
-        $delimiters = Arr::make([')']);
-        $pairs = Arr::make(['(' => ')', '[' => ']', '{' => '}']);
-        $closings = Arr::make([')' => true, ']' => true, '}' => true]);
-        $allowed = Arr::make([
-            T_ARRAY,
-            T_CLASS,
-            T_CONSTANT_ENCAPSED_STRING,
-            T_DNUMBER,
-            T_DOUBLE_ARROW,
-            T_DOUBLE_COLON,
-            T_LNUMBER,
-            T_NAME_QUALIFIED,
-            T_NS_SEPARATOR,
-            T_OBJECT_OPERATOR,
-            T_STRING,
-        ]);
-
-        while (!$delimiters->isEmpty()) {
-            if ($tokens->isEmpty()) {
-                return false;
-            }
-            $token = $tokens->shift();
-            if (Arr::is($token)) {
-                $type = Arr::make($token)->get(0);
-                if (!$allowed->has($type, true)
-                    || ($this->isCallableNameToken($token) && $tokens->get(0) === '(')
-                ) {
-                    return false;
-                }
-                continue;
-            }
-            if ($pairs->hasKey($token)) {
-                $delimiters->push($pairs->get($token));
-                continue;
-            }
-            if ($closings->hasKey($token) && $token !== $delimiters->pop()) {
-                return false;
-            }
+        if (!$this->consumeSafeMappingArguments($tokens)) {
+            return false;
         }
 
         while ($this->tokenIs($tokens->get(0), T_OBJECT_OPERATOR)) {
@@ -697,32 +729,55 @@ final class AddOnContractValidator extends Service
             ) {
                 return false;
             }
-            $delimiters = Arr::make([')']);
-            while (!$delimiters->isEmpty()) {
-                if ($tokens->isEmpty()) {
-                    return false;
-                }
-                $token = $tokens->shift();
-                if (Arr::is($token)) {
-                    $type = Arr::make($token)->get(0);
-                    if (!$allowed->has($type, true)
-                        || ($this->isCallableNameToken($token) && $tokens->get(0) === '(')
-                    ) {
-                        return false;
-                    }
-                    continue;
-                }
-                if ($pairs->hasKey($token)) {
-                    $delimiters->push($pairs->get($token));
-                    continue;
-                }
-                if ($closings->hasKey($token) && $token !== $delimiters->pop()) {
-                    return false;
-                }
+            if (!$this->consumeSafeMappingArguments($tokens)) {
+                return false;
             }
         }
 
         return $tokens->shift() === ';';
+    }
+
+    private function consumeSafeMappingArguments(Arr $tokens): bool
+    {
+        $delimiters = Arr::make([')']);
+        $pairs = Arr::make(['(' => ')', '[' => ']']);
+        $closings = Arr::make([')' => true, ']' => true]);
+        $previousToken = null;
+        while (!$delimiters->isEmpty()) {
+            if ($tokens->isEmpty()) {
+                return false;
+            }
+
+            $token = $tokens->shift();
+            if (Arr::is($token)) {
+                if (!$this->isSafeDeclarativeToken($token, $previousToken, $tokens)) {
+                    return false;
+                }
+                $previousToken = $token;
+                continue;
+            }
+            if ($token === '(' && $this->tokenCanBeInvoked($previousToken)) {
+                return false;
+            }
+            if ($pairs->hasKey($token)) {
+                $delimiters->push($pairs->get($token));
+                $previousToken = $token;
+                continue;
+            }
+            if ($closings->hasKey($token)) {
+                if ($token !== $delimiters->pop()) {
+                    return false;
+                }
+                $previousToken = $token;
+                continue;
+            }
+            if ($token !== ',') {
+                return false;
+            }
+            $previousToken = $token;
+        }
+
+        return true;
     }
 
     private function significantTokens(array $tokens): Arr
@@ -811,20 +866,32 @@ final class AddOnContractValidator extends Service
         }
         if ($this->tokenIs($token, T_STRING)) {
             $value = Str::make((string) Arr::make($token)->get(1))->lower()->val();
-            if (Arr::make(['false', 'null', 'true'])->has($value, true)) {
+            if (Arr::make(['false', 'null', 'true'])->has($value, true)
+                && $tokens->get(0) !== '('
+            ) {
                 return true;
             }
         }
+        if ($this->tokenTextIs($token, 'class')
+            && $this->tokenIs($previousToken, T_DOUBLE_COLON)
+        ) {
+            return true;
+        }
         if ($this->isCallableNameToken($token)) {
             return $this->tokenIs($tokens->get(0), T_DOUBLE_COLON)
-                && $this->tokenIs($tokens->get(1), T_CLASS);
+                && $this->tokenTextIs($tokens->get(1), 'class');
         }
         if ($this->tokenIs($token, T_DOUBLE_COLON)) {
-            return $this->tokenIs($tokens->get(0), T_CLASS);
+            return $this->tokenTextIs($tokens->get(0), 'class');
         }
 
-        return $this->tokenIs($token, T_CLASS)
-            && $this->tokenIs($previousToken, T_DOUBLE_COLON);
+        return false;
+    }
+
+    private function tokenTextIs($token, string $text): bool
+    {
+        return Arr::is($token)
+            && Str::make((string) Arr::make($token)->get(1))->lower()->val() === $text;
     }
 
     private function isComposerPackageName($name): bool

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -82,6 +82,7 @@ final class AddOnContractValidator extends Service
         $definition = $this->readJson($root, 'definition.json', $errors);
         $namespace = $this->validateMetadata($composer, $definition, $errors);
 
+        $this->validateInstalledIdentity($root, $definition, $errors);
         $this->validateRegistration($root, $namespace, $definition, $errors);
         $this->validateThemes($root, $definition, $errors);
         $this->validatePhpFiles($root, $namespace, $errors);
@@ -101,7 +102,7 @@ final class AddOnContractValidator extends Service
         }
 
         $name = $definition->get('name');
-        if (!Str::is($name) || !Str::make($name)->matches('/^[a-z][a-z0-9_]*$/')) {
+        if (!Str::is($name) || !Str::make($name)->matches('/^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$/')) {
             $errors->push($this->problem('definition_name', 'definition.json', 'Definition name must be a lowercase lifecycle-safe key.'));
         }
         if (!Str::is($namespace) || !Str::make($namespace)->matches('/^AddOns\\\\[A-Z][A-Za-z0-9]*$/')) {
@@ -128,6 +129,22 @@ final class AddOnContractValidator extends Service
         }
 
         return $namespace;
+    }
+
+    private function validateInstalledIdentity(string $root, array $definition, Arr $errors): void
+    {
+        if (FileSystem::fileBasename(dirname($root)) !== 'addons') {
+            return;
+        }
+
+        $name = Arr::make($definition)->get('name');
+        if (!Str::is($name) || FileSystem::fileBasename($root) !== $name) {
+            $errors->push($this->problem(
+                'installed_identity',
+                'definition.json',
+                'Installed directory name must match the add-on lifecycle key.'
+            ));
+        }
     }
 
     private function validatePhpFiles(string $root, string $namespace, Arr $errors): void
@@ -449,6 +466,7 @@ final class AddOnContractValidator extends Service
         $callableBodyDepth = 0;
         $waitingForCallableBody = false;
         $arrowClosureLevel = null;
+        $closedCallableExpression = false;
         $disallowed = Arr::make([
             T_EVAL,
             T_EXIT,
@@ -467,6 +485,12 @@ final class AddOnContractValidator extends Service
             }
 
             $token = $tokens->shift();
+            if ($closedCallableExpression && $token === '(') {
+                return false;
+            }
+            if ($closedCallableExpression && $token !== ')') {
+                $closedCallableExpression = false;
+            }
             if (Arr::is($token)) {
                 $type = Arr::make($token)->get(0);
                 if ($type === T_FUNCTION) {
@@ -501,9 +525,13 @@ final class AddOnContractValidator extends Service
             if ($closing->hasKey($token)) {
                 if ($arrowClosureLevel === $delimiters->count()) {
                     $arrowClosureLevel = null;
+                    $closedCallableExpression = true;
                 }
                 if ($token === '}' && $callableBodyDepth > 0) {
                     $callableBodyDepth--;
+                    if ($callableBodyDepth === 0) {
+                        $closedCallableExpression = true;
+                    }
                 }
                 if ($token !== $delimiters->pop()) {
                     return false;

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -323,12 +323,14 @@ final class AddOnContractValidator extends Service
             if (Str::is($source)) {
                 try {
                     $tokens = token_get_all($source, TOKEN_PARSE);
-                    $declared = $this->declaredClassName($tokens);
-                    if ($declared !== $class) {
+                    $declared = $this->registrationClassDeclaration($tokens);
+                    if ($declared->get('name') !== $class
+                        || !$declared->get('default_constructible')
+                    ) {
                         $errors->push($this->problem(
                             'registration_class',
                             $classPath,
-                            'Registration file must declare the configured class.'
+                            'Registration file must declare a concrete, publicly default-constructible configured class.'
                         ));
                     }
                 } catch (ParseError) {
@@ -408,7 +410,7 @@ final class AddOnContractValidator extends Service
         });
     }
 
-    private function declaredClassName(array $tokens): string
+    private function registrationClassDeclaration(array $tokens): Arr
     {
         $tokens = $this->significantTokens($tokens);
         $structuralDepth = 0;
@@ -421,6 +423,7 @@ final class AddOnContractValidator extends Service
         $parenthesisDepth = 0;
         $alternativeScopeDepth = 0;
         $alternativeScopePending = false;
+        $abstractClassPending = false;
         $alternativeOpenTokens = Arr::make([
             T_DECLARE,
             T_FOR,
@@ -468,13 +471,26 @@ final class AddOnContractValidator extends Service
                     $previousToken = $token;
                     continue;
                 }
-                if ($type !== T_CLASS
-                    || $structuralDepth !== $namespaceDepth
-                    || $alternativeScopeDepth !== 0
-                    || $alternativeScopePending
-                    || $this->tokenIs($previousToken, T_NEW)
-                    || $this->tokenIs($previousToken, T_ABSTRACT)
+                if ($type === T_ABSTRACT
+                    && $structuralDepth === $namespaceDepth
+                    && $alternativeScopeDepth === 0
+                    && !$alternativeScopePending
                 ) {
+                    $abstractClassPending = true;
+                    $previousToken = $token;
+                    continue;
+                }
+                if ($type !== T_CLASS) {
+                    $previousToken = $token;
+                    continue;
+                }
+
+                $validScope = $structuralDepth === $namespaceDepth
+                    && $alternativeScopeDepth === 0
+                    && !$alternativeScopePending
+                    && !$this->tokenIs($previousToken, T_NEW);
+                if (!$validScope || $abstractClassPending) {
+                    $abstractClassPending = false;
                     $previousToken = $token;
                     continue;
                 }
@@ -482,13 +498,16 @@ final class AddOnContractValidator extends Service
                 $name = $tokens->shift();
 
                 if (!$this->tokenIs($name, T_STRING)) {
-                    return '';
+                    return Arr::make([]);
                 }
 
-                return Str::make($namespace->val())
-                    ->append($namespace->isEmpty() ? '' : '\\')
-                    ->append((string) Arr::make($name)->get(1))
-                    ->val();
+                return Arr::make([
+                    'name' => Str::make($namespace->val())
+                        ->append($namespace->isEmpty() ? '' : '\\')
+                        ->append((string) Arr::make($name)->get(1))
+                        ->val(),
+                    'default_constructible' => $this->classHasPublicDefaultConstructor($tokens),
+                ]);
             }
             if ($token === '}' && $interpolationDepth > 0) {
                 $interpolationDepth--;
@@ -529,7 +548,112 @@ final class AddOnContractValidator extends Service
             $previousToken = $token;
         }
 
-        return '';
+        return Arr::make([]);
+    }
+
+    private function classHasPublicDefaultConstructor(Arr $tokens): bool
+    {
+        while (!$tokens->isEmpty() && $tokens->shift() !== '{') {
+        }
+        if ($tokens->isEmpty()) {
+            return false;
+        }
+
+        $bodyDepth = 1;
+        $visibility = T_PUBLIC;
+        while (!$tokens->isEmpty() && $bodyDepth > 0) {
+            $token = $tokens->shift();
+            if ($token === '{') {
+                $bodyDepth++;
+                continue;
+            }
+            if ($token === '}') {
+                $bodyDepth--;
+                if ($bodyDepth === 1) {
+                    $visibility = T_PUBLIC;
+                }
+                continue;
+            }
+            if ($bodyDepth !== 1) {
+                continue;
+            }
+            if ($token === ';') {
+                $visibility = T_PUBLIC;
+                continue;
+            }
+            if ($this->tokenIsOneOf($token, [T_PRIVATE, T_PROTECTED, T_PUBLIC])) {
+                $visibility = (int) Arr::make($token)->get(0);
+                continue;
+            }
+            if (!$this->tokenIs($token, T_FUNCTION)) {
+                continue;
+            }
+
+            $name = $tokens->shift();
+            if ($name === '&'
+                || $this->tokenIsOneOf($name, [
+                    T_AMPERSAND_FOLLOWED_BY_VAR_OR_VARARG,
+                    T_AMPERSAND_NOT_FOLLOWED_BY_VAR_OR_VARARG,
+                ])
+            ) {
+                $name = $tokens->shift();
+            }
+            if (!$this->tokenIs($name, T_STRING)
+                || Str::make((string) Arr::make($name)->get(1))->lower()->val() !== '__construct'
+            ) {
+                continue;
+            }
+
+            return $visibility === T_PUBLIC
+                && $this->constructorAllowsNoArguments($tokens);
+        }
+
+        return true;
+    }
+
+    private function constructorAllowsNoArguments(Arr $tokens): bool
+    {
+        while (!$tokens->isEmpty() && $tokens->shift() !== '(') {
+        }
+        if ($tokens->isEmpty()) {
+            return false;
+        }
+
+        $depth = 1;
+        $hasParameter = false;
+        $optional = false;
+        while (!$tokens->isEmpty()) {
+            $token = $tokens->shift();
+            if ($token === '(' || $token === '[' || $token === '{') {
+                $depth++;
+                continue;
+            }
+            if ($token === ')' || $token === ']' || $token === '}') {
+                $depth--;
+                if ($depth === 0) {
+                    return !$hasParameter || $optional;
+                }
+                continue;
+            }
+            if ($depth !== 1) {
+                continue;
+            }
+            if ($token === ',') {
+                if ($hasParameter && !$optional) {
+                    return false;
+                }
+                $hasParameter = false;
+                $optional = false;
+                continue;
+            }
+            if ($token === '=' || $this->tokenIs($token, T_ELLIPSIS)) {
+                $optional = true;
+            } elseif ($this->tokenIs($token, T_VARIABLE)) {
+                $hasParameter = true;
+            }
+        }
+
+        return false;
     }
 
     private function returnsCallableFactory(array $tokens, string $class): bool

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -100,11 +100,7 @@ final class AddOnContractValidator extends Service
         if ($composer->get('type') !== 'opus-addon') {
             $errors->push($this->problem('composer_type', 'composer.json', 'Composer type must be opus-addon.'));
         }
-        if (!Str::is($composer->get('name'))
-            || !Str::make($composer->get('name'))->matches(
-                '/^[a-z0-9](?:[_.-]?[a-z0-9]+)*\/[a-z0-9](?:[_.-]?[a-z0-9]+)*$/'
-            )
-        ) {
+        if (!$this->isComposerPackageName($composer->get('name'))) {
             $errors->push($this->problem(
                 'composer_name',
                 'composer.json',
@@ -125,6 +121,25 @@ final class AddOnContractValidator extends Service
         }
         if (!Str::is($definition->get('version')) || Str::make($definition->get('version'))->trim()->isEmpty()) {
             $errors->push($this->problem('definition_version', 'definition.json', 'Definition version must be a nonempty string.'));
+        }
+
+        $libraries = $definition->get('libraries');
+        if (!Arr::is($libraries)) {
+            $errors->push($this->problem(
+                'libraries_manifest',
+                'definition.json',
+                'Libraries must be an array of Composer package names.'
+            ));
+        } else {
+            Arr::make($libraries)->each(function ($library) use ($errors): void {
+                if (!$this->isComposerPackageName($library)) {
+                    $errors->push($this->problem(
+                        'libraries_manifest',
+                        'definition.json',
+                        'Every library must use a valid lowercase Composer package name.'
+                    ));
+                }
+            });
         }
 
         $extra = Arr::make(Arr::is($composer->get('extra')) ? $composer->get('extra') : []);
@@ -479,19 +494,6 @@ final class AddOnContractValidator extends Service
         $arrowClosureLevel = null;
         $closedCallableExpression = false;
         $previousToken = null;
-        $disallowed = Arr::make([
-            T_EVAL,
-            T_EXIT,
-            T_INCLUDE,
-            T_INCLUDE_ONCE,
-            T_NEW,
-            T_PRINT,
-            T_REQUIRE,
-            T_REQUIRE_ONCE,
-            T_VARIABLE,
-            T_YIELD,
-            T_YIELD_FROM,
-        ]);
         while (!$delimiters->isEmpty()) {
             if ($tokens->isEmpty()) {
                 return false;
@@ -499,12 +501,6 @@ final class AddOnContractValidator extends Service
 
             $token = $tokens->shift();
             if ($closedCallableExpression && $token === '(') {
-                return false;
-            }
-            if ($callableBodyDepth === 0
-                && $arrowClosureLevel === null
-                && $token === '`'
-            ) {
                 return false;
             }
             if ($callableBodyDepth === 0
@@ -527,8 +523,7 @@ final class AddOnContractValidator extends Service
                 } elseif ($callableBodyDepth === 0
                     && !$waitingForCallableBody
                     && $arrowClosureLevel === null
-                    && ($disallowed->has($type, true)
-                        || ($this->isCallableNameToken($token) && $tokens->get(0) === '('))
+                    && !$this->isSafeDeclarativeToken($token, $previousToken, $tokens)
                 ) {
                     return false;
                 }
@@ -537,6 +532,13 @@ final class AddOnContractValidator extends Service
             }
             if ($token === ',' && $arrowClosureLevel === $delimiters->count()) {
                 $arrowClosureLevel = null;
+            }
+            if ($callableBodyDepth === 0
+                && !$waitingForCallableBody
+                && $arrowClosureLevel === null
+                && !Arr::make(['(', ')', '[', ']', ','])->has($token, true)
+            ) {
+                return false;
             }
             if ($pairs->hasKey($token)) {
                 $delimiters->push($pairs->get($token));
@@ -783,6 +785,54 @@ final class AddOnContractValidator extends Service
     {
         return $this->tokenIs($token, T_CONSTANT_ENCAPSED_STRING)
             || Arr::make([']', ')', '}'])->has($token, true);
+    }
+
+    private function isSafeDeclarativeToken($token, $previousToken, Arr $tokens): bool
+    {
+        if ($this->tokenIsOneOf($token, [
+            T_ARRAY,
+            T_CLASS_C,
+            T_CONSTANT_ENCAPSED_STRING,
+            T_DIR,
+            T_DNUMBER,
+            T_DOUBLE_ARROW,
+            T_FILE,
+            T_FUNC_C,
+            T_LINE,
+            T_LNUMBER,
+            T_METHOD_C,
+            T_NS_C,
+            T_TRAIT_C,
+        ])) {
+            return true;
+        }
+        if ($this->tokenIs($token, T_STATIC)) {
+            return $this->tokenIsOneOf($tokens->get(0), [T_FN, T_FUNCTION]);
+        }
+        if ($this->tokenIs($token, T_STRING)) {
+            $value = Str::make((string) Arr::make($token)->get(1))->lower()->val();
+            if (Arr::make(['false', 'null', 'true'])->has($value, true)) {
+                return true;
+            }
+        }
+        if ($this->isCallableNameToken($token)) {
+            return $this->tokenIs($tokens->get(0), T_DOUBLE_COLON)
+                && $this->tokenIs($tokens->get(1), T_CLASS);
+        }
+        if ($this->tokenIs($token, T_DOUBLE_COLON)) {
+            return $this->tokenIs($tokens->get(0), T_CLASS);
+        }
+
+        return $this->tokenIs($token, T_CLASS)
+            && $this->tokenIs($previousToken, T_DOUBLE_COLON);
+    }
+
+    private function isComposerPackageName($name): bool
+    {
+        return Str::is($name)
+            && Str::make($name)->matches(
+                '/^[a-z0-9](?:[_.-]?[a-z0-9]+)*\/[a-z0-9](?:[_.-]?[a-z0-9]+)*$/'
+            );
     }
 
     private function files(string $root, string $extension): array

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -473,6 +473,7 @@ final class AddOnContractValidator extends Service
                     || $alternativeScopeDepth !== 0
                     || $alternativeScopePending
                     || $this->tokenIs($previousToken, T_NEW)
+                    || $this->tokenIs($previousToken, T_ABSTRACT)
                 ) {
                     $previousToken = $token;
                     continue;
@@ -803,6 +804,7 @@ final class AddOnContractValidator extends Service
         $callableBodyDepth = 0;
         $pendingCallableBodies = 0;
         $arrowClosureLevels = Arr::make([]);
+        $yieldLevels = Arr::make([]);
         $interpolationDepth = 0;
         $closedCallableExpression = false;
         $previousToken = null;
@@ -839,6 +841,8 @@ final class AddOnContractValidator extends Service
                         'level' => $delimiters->count(),
                         'started' => false,
                     ]);
+                } elseif ($type === T_YIELD && $arrowClosureLevels->isNotEmpty()) {
+                    $yieldLevels->push($delimiters->count());
                 } elseif ($type === T_DOUBLE_ARROW && $arrowClosureLevels->isNotEmpty()) {
                     $index = $arrowClosureLevels->count() - 1;
                     $arrow = Arr::make($arrowClosureLevels->get($index));
@@ -847,6 +851,13 @@ final class AddOnContractValidator extends Service
                     ) {
                         $arrow->set('started', true);
                         $arrowClosureLevels->set($index, $arrow->val());
+                        $previousToken = $token;
+                        continue;
+                    }
+                    if ($yieldLevels->isNotEmpty()
+                        && $yieldLevels->get($yieldLevels->count() - 1) === $delimiters->count()
+                    ) {
+                        $yieldLevels->pop();
                         $previousToken = $token;
                         continue;
                     }
@@ -884,6 +895,12 @@ final class AddOnContractValidator extends Service
                     && Arr::make($arrowClosureLevels->get($arrowClosureLevels->count() - 1))
                         ->get('level') === $delimiters->count()
                 );
+            }
+            if (($token === ',' || $closing->hasKey($token))
+                && $yieldLevels->isNotEmpty()
+                && $yieldLevels->get($yieldLevels->count() - 1) === $delimiters->count()
+            ) {
+                $yieldLevels->pop();
             }
             if ($callableBodyDepth === 0
                 && $pendingCallableBodies === 0
@@ -933,6 +950,7 @@ final class AddOnContractValidator extends Service
         return $pendingCallableBodies === 0
             && $callableBodyDepth === 0
             && $arrowClosureLevels->isEmpty()
+            && $yieldLevels->isEmpty()
             && $interpolationDepth === 0;
     }
 

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -448,10 +448,10 @@ final class AddOnContractValidator extends Service
         $pairs = Arr::make(['(' => ')', '[' => ']', '{' => '}']);
         $callableBodyDepth = 0;
         $waitingForCallableBody = false;
+        $arrowClosureLevel = null;
         $disallowed = Arr::make([
             T_EVAL,
             T_EXIT,
-            T_FN,
             T_INCLUDE,
             T_INCLUDE_ONCE,
             T_NEW,
@@ -471,14 +471,20 @@ final class AddOnContractValidator extends Service
                 $type = Arr::make($token)->get(0);
                 if ($type === T_FUNCTION) {
                     $waitingForCallableBody = true;
+                } elseif ($type === T_FN) {
+                    $arrowClosureLevel = $delimiters->count();
                 } elseif ($callableBodyDepth === 0
                     && !$waitingForCallableBody
+                    && $arrowClosureLevel === null
                     && ($disallowed->has($type, true)
-                        || ($type === T_STRING && $tokens->get(0) === '('))
+                        || ($this->isCallableNameToken($token) && $tokens->get(0) === '('))
                 ) {
                     return false;
                 }
                 continue;
+            }
+            if ($token === ',' && $arrowClosureLevel === $delimiters->count()) {
+                $arrowClosureLevel = null;
             }
             if ($pairs->hasKey($token)) {
                 $delimiters->push($pairs->get($token));
@@ -493,6 +499,9 @@ final class AddOnContractValidator extends Service
                 continue;
             }
             if ($closing->hasKey($token)) {
+                if ($arrowClosureLevel === $delimiters->count()) {
+                    $arrowClosureLevel = null;
+                }
                 if ($token === '}' && $callableBodyDepth > 0) {
                     $callableBodyDepth--;
                 }
@@ -502,7 +511,11 @@ final class AddOnContractValidator extends Service
             }
         }
 
-        if ($waitingForCallableBody || $callableBodyDepth !== 0 || $tokens->shift() !== ';') {
+        if ($waitingForCallableBody
+            || $callableBodyDepth !== 0
+            || $arrowClosureLevel !== null
+            || $tokens->shift() !== ';'
+        ) {
             return false;
         }
         if ($this->tokenIs($tokens->get(0), T_CLOSE_TAG)) {
@@ -602,7 +615,7 @@ final class AddOnContractValidator extends Service
             if (Arr::is($token)) {
                 $type = Arr::make($token)->get(0);
                 if (!$allowed->has($type, true)
-                    || ($type === T_STRING && $tokens->get(0) === '(')
+                    || ($this->isCallableNameToken($token) && $tokens->get(0) === '(')
                 ) {
                     return false;
                 }
@@ -633,7 +646,7 @@ final class AddOnContractValidator extends Service
                 if (Arr::is($token)) {
                     $type = Arr::make($token)->get(0);
                     if (!$allowed->has($type, true)
-                        || ($type === T_STRING && $tokens->get(0) === '(')
+                        || ($this->isCallableNameToken($token) && $tokens->get(0) === '(')
                     ) {
                         return false;
                     }
@@ -696,6 +709,16 @@ final class AddOnContractValidator extends Service
     {
         return Arr::is($token)
             && Arr::make($types)->has(Arr::make($token)->get(0), true);
+    }
+
+    private function isCallableNameToken($token): bool
+    {
+        return $this->tokenIsOneOf($token, [
+            T_NAME_FULLY_QUALIFIED,
+            T_NAME_QUALIFIED,
+            T_NAME_RELATIVE,
+            T_STRING,
+        ]);
     }
 
     private function files(string $root, string $extension): array

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -1,0 +1,337 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Business\Services;
+
+use BlueFission\Arr;
+use BlueFission\Data\FileSystem;
+use BlueFission\Services\Service;
+use BlueFission\Str;
+use BlueFission\Vibrato\Validation\VibeSyntaxValidator;
+use ParseError;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use Throwable;
+
+final class AddOnContractValidator extends Service
+{
+    private VibeSyntaxValidator $vibeValidator;
+
+    private const REQUIRED_FILES = [
+        'composer.json',
+        'definition.json',
+        'main.php',
+        'README.md',
+        'logic/Registration/AddOnRegistration.php',
+        'mapping/api.php',
+        'mapping/app.php',
+        'mapping/console.php',
+        'mapping/default.php',
+        'mapping/menus.php',
+        'resource/markup/default.vibe',
+        'phpunit.xml',
+        'tests/bootstrap.php',
+    ];
+
+    private const REQUIRED_DIRECTORIES = [
+        'datasources/generator',
+        'datasources/structure',
+        'logic/Business/Http',
+        'logic/Business/Managers',
+        'logic/Business/Prompts',
+        'logic/Domain/Models',
+        'logic/Domain/Queries',
+        'logic/Domain/Repositories',
+        'logic/Domain/Values',
+        'resource/markup',
+        'resource/src',
+        'tests',
+    ];
+
+    public function __construct(?VibeSyntaxValidator $vibeValidator = null)
+    {
+        parent::__construct();
+
+        $this->vibeValidator = $vibeValidator ?? new VibeSyntaxValidator();
+    }
+
+    public function validate(string $root): array
+    {
+        $errors = Arr::make([]);
+        $warnings = Arr::make([]);
+        $resolvedRoot = realpath($root);
+
+        if (!Str::is($resolvedRoot) || !FileSystem::directoryExists((string) $resolvedRoot)) {
+            $errors->push($this->problem('root_missing', '.', 'Add-on root directory was not found.'));
+
+            return $this->report($errors, $warnings);
+        }
+
+        $root = (string) $resolvedRoot;
+        foreach (Arr::make(self::REQUIRED_FILES) as $path) {
+            if (!FileSystem::fileExists($this->path($root, (string) $path))) {
+                $errors->push($this->problem('file_missing', (string) $path, 'Required file is missing.'));
+            }
+        }
+        foreach (Arr::make(self::REQUIRED_DIRECTORIES) as $path) {
+            if (!FileSystem::directoryExists($this->path($root, (string) $path))) {
+                $errors->push($this->problem('directory_missing', (string) $path, 'Required directory is missing.'));
+            }
+        }
+
+        $composer = $this->readJson($root, 'composer.json', $errors);
+        $definition = $this->readJson($root, 'definition.json', $errors);
+        $namespace = $this->validateMetadata($composer, $definition, $errors);
+
+        $this->validatePhpFiles($root, $namespace, $errors);
+        $this->validateVibeFiles($root, $errors);
+
+        return $this->report($errors, $warnings);
+    }
+
+    private function validateMetadata(array $composer, array $definition, Arr $errors): string
+    {
+        $composer = Arr::make($composer);
+        $definition = Arr::make($definition);
+        $namespace = $definition->get('namespace');
+
+        if ($composer->get('type') !== 'opus-addon') {
+            $errors->push($this->problem('composer_type', 'composer.json', 'Composer type must be opus-addon.'));
+        }
+
+        $name = $definition->get('name');
+        if (!Str::is($name) || !Str::make($name)->matches('/^[a-z][a-z0-9_]*$/')) {
+            $errors->push($this->problem('definition_name', 'definition.json', 'Definition name must be a lowercase lifecycle-safe key.'));
+        }
+        if (!Str::is($namespace) || !Str::make($namespace)->matches('/^AddOns\\\\[A-Z][A-Za-z0-9]*$/')) {
+            $errors->push($this->problem('definition_namespace', 'definition.json', 'Namespace must use AddOns\\PackageName.'));
+            $namespace = '';
+        }
+        if ($definition->get('primary_file') !== 'main.php') {
+            $errors->push($this->problem('primary_file', 'definition.json', 'Primary file must be main.php.'));
+        }
+        if (!Str::is($definition->get('version')) || Str::make($definition->get('version'))->trim()->isEmpty()) {
+            $errors->push($this->problem('definition_version', 'definition.json', 'Definition version must be a nonempty string.'));
+        }
+
+        $extra = Arr::make(Arr::is($composer->get('extra')) ? $composer->get('extra') : []);
+        if ($extra->get('installer-name') !== $name) {
+            $errors->push($this->problem('installer_name', 'composer.json', 'Installer name must match definition name.'));
+        }
+
+        $autoload = Arr::make(Arr::is($composer->get('autoload')) ? $composer->get('autoload') : []);
+        $psr4 = Arr::make(Arr::is($autoload->get('psr-4')) ? $autoload->get('psr-4') : []);
+        $autoloadNamespace = $namespace === '' ? '' : $namespace . '\\';
+        if ($autoloadNamespace === '' || $psr4->get($autoloadNamespace) !== 'logic/') {
+            $errors->push($this->problem('psr4_mapping', 'composer.json', 'Package namespace must map to logic/.'));
+        }
+
+        return $namespace;
+    }
+
+    private function validatePhpFiles(string $root, string $namespace, Arr $errors): void
+    {
+        foreach ($this->files($root, 'php') as $file) {
+            $relative = $this->relative($root, $file);
+            $source = FileSystem::fileContents($file);
+            if (!Str::is($source)) {
+                $errors->push($this->problem('php_unreadable', $relative, 'PHP file could not be read.'));
+                continue;
+            }
+
+            try {
+                $tokens = token_get_all($source, TOKEN_PARSE);
+            } catch (ParseError $exception) {
+                $errors->push($this->problem('php_syntax', $relative, $exception->getMessage()));
+                continue;
+            }
+
+            if (Str::startsWith($relative, 'logic/') && $namespace !== '') {
+                $declared = $this->declaredNamespace($tokens);
+                $directory = Str::make(dirname(Str::sub($relative, strlen('logic/'))))
+                    ->replace('.', '')
+                    ->replace('/', '\\')
+                    ->replace('\\\\', '\\')
+                    ->trim('\\')
+                    ->val();
+                $expected = $directory === '' ? $namespace : $namespace . '\\' . $directory;
+                if ($declared !== $expected) {
+                    $errors->push($this->problem('namespace_mismatch', $relative, "PHP namespace must be {$expected}."));
+                }
+            }
+
+            if (Str::startsWith($relative, 'mapping/') && !$this->hasTopLevelArrayReturn($tokens)) {
+                $errors->push($this->problem('mapping_contract', $relative, 'Mapping file must return a declarative array.'));
+            }
+        }
+    }
+
+    private function validateVibeFiles(string $root, Arr $errors): void
+    {
+        $markup = $this->path($root, 'resource/markup');
+        if (!FileSystem::directoryExists($markup)) {
+            return;
+        }
+
+        foreach ($this->allFiles($markup) as $file) {
+            if (!Str::make($file)->endsWith('.vibe')) {
+                $errors->push($this->problem('template_extension', $this->relative($root, $file), 'Server-rendered templates must use the .vibe extension.'));
+                continue;
+            }
+
+            $source = FileSystem::fileContents($file);
+            if (!Str::is($source)) {
+                $errors->push($this->problem('template_unreadable', $this->relative($root, $file), 'Vibe template could not be read.'));
+                continue;
+            }
+
+            $validation = Arr::make($this->vibeValidator->validate($source)->toArray());
+            if (!$validation->get('valid')) {
+                $errors->push($this->problem('template_syntax', $this->relative($root, $file), 'Vibe template syntax is invalid.'));
+            }
+        }
+    }
+
+    private function readJson(string $root, string $relative, Arr $errors): array
+    {
+        $path = $this->path($root, $relative);
+        if (!FileSystem::fileExists($path)) {
+            return [];
+        }
+
+        $contents = FileSystem::fileContents($path);
+        if (!Str::is($contents)) {
+            $errors->push($this->problem('json_unreadable', $relative, 'JSON file could not be read.'));
+
+            return [];
+        }
+
+        try {
+            $decoded = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable $exception) {
+            $errors->push($this->problem('json_invalid', $relative, $exception->getMessage()));
+
+            return [];
+        }
+
+        if (!Arr::is($decoded)) {
+            $errors->push($this->problem('json_shape', $relative, 'JSON root must be an object.'));
+
+            return [];
+        }
+
+        return $decoded;
+    }
+
+    private function declaredNamespace(array $tokens): string
+    {
+        $collect = false;
+        $namespace = Str::make('');
+
+        foreach ($tokens as $token) {
+            if (is_array($token) && $token[0] === T_NAMESPACE) {
+                $collect = true;
+                continue;
+            }
+            if (!$collect) {
+                continue;
+            }
+            if ($token === ';' || $token === '{') {
+                break;
+            }
+            if (is_array($token) && Arr::make([T_STRING, T_NAME_QUALIFIED, T_NS_SEPARATOR])->has($token[0], true)) {
+                $namespace->append($token[1]);
+            }
+        }
+
+        return $namespace->val();
+    }
+
+    private function hasTopLevelArrayReturn(array $tokens): bool
+    {
+        $depth = 0;
+        $returnFound = false;
+
+        foreach ($tokens as $token) {
+            if ($token === '{') {
+                $depth++;
+                continue;
+            }
+            if ($token === '}') {
+                $depth--;
+                continue;
+            }
+            if ($returnFound) {
+                if (is_array($token) && Arr::make([T_WHITESPACE, T_COMMENT, T_DOC_COMMENT])->has($token[0], true)) {
+                    continue;
+                }
+
+                return $token === '[' || (is_array($token) && $token[0] === T_ARRAY);
+            }
+            if ($depth === 0 && is_array($token) && $token[0] === T_RETURN) {
+                $returnFound = true;
+            }
+        }
+
+        return false;
+    }
+
+    private function files(string $root, string $extension): array
+    {
+        return Arr::make($this->allFiles($root))
+            ->filter(fn (string $file): bool => Str::make($file)->endsWith('.' . $extension))
+            ->values()
+            ->val();
+    }
+
+    private function allFiles(string $root): array
+    {
+        if (!FileSystem::directoryExists($root)) {
+            return [];
+        }
+
+        $files = Arr::make([]);
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($root, RecursiveDirectoryIterator::SKIP_DOTS)
+        );
+        foreach ($iterator as $item) {
+            if ($item->isFile()) {
+                $files->push($item->getPathname());
+            }
+        }
+
+        return $files->val();
+    }
+
+    private function report(Arr $errors, Arr $warnings): array
+    {
+        return [
+            'valid' => $errors->isEmpty(),
+            'errors' => $errors->val(),
+            'warnings' => $warnings->val(),
+            'error_count' => $errors->count(),
+            'warning_count' => $warnings->count(),
+        ];
+    }
+
+    private function problem(string $code, string $path, string $message): array
+    {
+        return compact('code', 'path', 'message');
+    }
+
+    private function path(string $root, string $relative): string
+    {
+        return $root . DIRECTORY_SEPARATOR . Str::make($relative)
+            ->replace('/', DIRECTORY_SEPARATOR)
+            ->val();
+    }
+
+    private function relative(string $root, string $path): string
+    {
+        return Str::make(substr($path, strlen($root)))
+            ->trim('/\\')
+            ->replace('\\', '/')
+            ->val();
+    }
+}

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -490,6 +490,12 @@ final class AddOnContractValidator extends Service
                 return false;
             }
             if ($callableBodyDepth === 0
+                && $arrowClosureLevel === null
+                && $token === '`'
+            ) {
+                return false;
+            }
+            if ($callableBodyDepth === 0
                 && !$waitingForCallableBody
                 && $arrowClosureLevel === null
                 && $token === '('

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -842,13 +842,16 @@ final class AddOnContractValidator extends Service
                 } elseif ($type === T_DOUBLE_ARROW && $arrowClosureLevels->isNotEmpty()) {
                     $index = $arrowClosureLevels->count() - 1;
                     $arrow = Arr::make($arrowClosureLevels->get($index));
-                    if (!$arrow->get('started')) {
+                    if (!$arrow->get('started')
+                        && $arrow->get('level') === $delimiters->count()
+                    ) {
                         $arrow->set('started', true);
                         $arrowClosureLevels->set($index, $arrow->val());
                         $previousToken = $token;
                         continue;
                     }
-                    while ($arrowClosureLevels->isNotEmpty()
+                    while ($arrow->get('started')
+                        && $arrowClosureLevels->isNotEmpty()
                         && Arr::make($arrowClosureLevels->get($arrowClosureLevels->count() - 1))
                             ->get('level') === $delimiters->count()
                     ) {

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -6,13 +6,13 @@ namespace App\Business\Services;
 
 use BlueFission\Arr;
 use BlueFission\Data\FileSystem;
+use BlueFission\Net\HTTP;
 use BlueFission\Services\Service;
 use BlueFission\Str;
 use BlueFission\Vibrato\Validation\VibeSyntaxValidator;
 use ParseError;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
-use Throwable;
 
 final class AddOnContractValidator extends Service
 {
@@ -23,13 +23,11 @@ final class AddOnContractValidator extends Service
         'definition.json',
         'main.php',
         'README.md',
-        'logic/Registration/AddOnRegistration.php',
         'mapping/api.php',
         'mapping/app.php',
         'mapping/console.php',
         'mapping/default.php',
         'mapping/menus.php',
-        'resource/markup/default.vibe',
         'phpunit.xml',
         'tests/bootstrap.php',
     ];
@@ -84,6 +82,8 @@ final class AddOnContractValidator extends Service
         $definition = $this->readJson($root, 'definition.json', $errors);
         $namespace = $this->validateMetadata($composer, $definition, $errors);
 
+        $this->validateRegistration($root, $namespace, $definition, $errors);
+        $this->validateThemes($root, $definition, $errors);
         $this->validatePhpFiles($root, $namespace, $errors);
         $this->validateVibeFiles($root, $errors);
 
@@ -149,7 +149,7 @@ final class AddOnContractValidator extends Service
 
             if (Str::startsWith($relative, 'logic/') && $namespace !== '') {
                 $declared = $this->declaredNamespace($tokens);
-                $directory = Str::make(dirname(Str::sub($relative, strlen('logic/'))))
+                $directory = Str::make(dirname(Str::sub($relative, Str::len('logic/'))))
                     ->replace('.', '')
                     ->replace('/', '\\')
                     ->replace('\\\\', '\\')
@@ -161,8 +161,12 @@ final class AddOnContractValidator extends Service
                 }
             }
 
-            if (Str::startsWith($relative, 'mapping/') && !$this->hasTopLevelArrayReturn($tokens)) {
-                $errors->push($this->problem('mapping_contract', $relative, 'Mapping file must return a declarative array.'));
+            if (Str::startsWith($relative, 'mapping/') && !$this->isSupportedMapping($tokens)) {
+                $errors->push($this->problem(
+                    'mapping_contract',
+                    $relative,
+                    'Mapping file must return a declarative array or contain only supported Mapping registrations.'
+                ));
             }
         }
     }
@@ -207,16 +211,10 @@ final class AddOnContractValidator extends Service
             return [];
         }
 
-        try {
-            $decoded = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
-        } catch (Throwable $exception) {
-            $errors->push($this->problem('json_invalid', $relative, $exception->getMessage()));
-
-            return [];
-        }
+        $decoded = HTTP::jsonDecode($contents, true);
 
         if (!Arr::is($decoded)) {
-            $errors->push($this->problem('json_shape', $relative, 'JSON root must be an object.'));
+            $errors->push($this->problem('json_invalid', $relative, 'JSON root must be a valid object.'));
 
             return [];
         }
@@ -229,8 +227,9 @@ final class AddOnContractValidator extends Service
         $collect = false;
         $namespace = Str::make('');
 
+        $namespaceTokens = Arr::make([T_STRING, T_NAME_QUALIFIED, T_NS_SEPARATOR]);
         foreach ($tokens as $token) {
-            if (is_array($token) && $token[0] === T_NAMESPACE) {
+            if (Arr::is($token) && $token[0] === T_NAMESPACE) {
                 $collect = true;
                 continue;
             }
@@ -240,7 +239,7 @@ final class AddOnContractValidator extends Service
             if ($token === ';' || $token === '{') {
                 break;
             }
-            if (is_array($token) && Arr::make([T_STRING, T_NAME_QUALIFIED, T_NS_SEPARATOR])->has($token[0], true)) {
+            if (Arr::is($token) && $namespaceTokens->has($token[0], true)) {
                 $namespace->append($token[1]);
             }
         }
@@ -248,12 +247,151 @@ final class AddOnContractValidator extends Service
         return $namespace->val();
     }
 
-    private function hasTopLevelArrayReturn(array $tokens): bool
+    private function validateRegistration(string $root, string $namespace, array $definition, Arr $errors): void
     {
-        $depth = 0;
-        $returnFound = false;
+        $definition = Arr::make($definition);
+        $registration = Arr::make(
+            Arr::is($definition->get('registration')) ? $definition->get('registration') : []
+        );
+        $class = $registration->get('class');
+        $factory = $registration->get('factory');
 
-        foreach ($tokens as $token) {
+        if (!Str::is($class)
+            || $namespace === ''
+            || !Str::startsWith((string) $class, $namespace . '\\')
+        ) {
+            $errors->push($this->problem(
+                'registration_class',
+                'definition.json',
+                'Registration class must be declared beneath the package namespace.'
+            ));
+            return;
+        }
+
+        $classPath = 'logic/' . Str::make(Str::sub((string) $class, Str::len($namespace . '\\')))
+            ->replace('\\', '/')
+            ->append('.php')
+            ->val();
+        $classFile = $this->path($root, $classPath);
+        if (!FileSystem::fileExists($classFile)) {
+            $errors->push($this->problem('registration_class', $classPath, 'Registration class file is missing.'));
+        } else {
+            $source = FileSystem::fileContents($classFile);
+            if (Str::is($source)) {
+                try {
+                    $tokens = token_get_all($source, TOKEN_PARSE);
+                    $declared = Str::make($this->declaredNamespace($tokens))
+                        ->append('\\')
+                        ->append($this->declaredClass($tokens))
+                        ->val();
+                    if ($declared !== $class) {
+                        $errors->push($this->problem(
+                            'registration_class',
+                            $classPath,
+                            'Registration file must declare the configured class.'
+                        ));
+                    }
+                } catch (ParseError) {
+                    // The PHP syntax pass reports the malformed class file.
+                }
+            }
+        }
+
+        if (!Str::is($factory) || $factory !== $definition->get('primary_file')) {
+            $errors->push($this->problem(
+                'registration_factory',
+                'definition.json',
+                'Registration factory must reference the declared primary file.'
+            ));
+            return;
+        }
+
+        $factoryPath = $this->path($root, (string) $factory);
+        $source = FileSystem::fileContents($factoryPath);
+        if (!Str::is($source)) {
+            return;
+        }
+
+        try {
+            $tokens = token_get_all($source, TOKEN_PARSE);
+        } catch (ParseError) {
+            return;
+        }
+
+        if (!$this->returnsCallableFactory($tokens)) {
+            $errors->push($this->problem(
+                'registration_factory',
+                (string) $factory,
+                'Registration factory must return a callable.'
+            ));
+        }
+    }
+
+    private function validateThemes(string $root, array $definition, Arr $errors): void
+    {
+        $themes = Arr::make(
+            Arr::is(Arr::make($definition)->get('themes'))
+                ? Arr::make($definition)->get('themes')
+                : []
+        );
+        if ($themes->isEmpty()) {
+            $errors->push($this->problem(
+                'theme_manifest',
+                'definition.json',
+                'At least one Vibe theme entrypoint must be declared.'
+            ));
+            return;
+        }
+
+        $themes->each(function ($descriptor, $name) use ($root, $errors): void {
+            $descriptor = Arr::make(Arr::is($descriptor) ? $descriptor : []);
+            $directory = Str::make((string) $descriptor->get('directory'))->trim('/\\')->val();
+            $entrypoint = Str::make((string) $descriptor->get('entrypoint'))->trim('/\\')->val();
+            $relative = Str::make($directory)
+                ->append($directory === '' ? '' : '/')
+                ->append($entrypoint)
+                ->replace('\\', '/')
+                ->val();
+
+            if ($entrypoint === ''
+                || !Str::make($entrypoint)->endsWith('.vibe')
+                || Str::make($relative)->split('/')->has('..', true)
+                || !Str::startsWith($relative, 'resource/markup/')
+                || !FileSystem::fileExists($this->path($root, $relative))
+            ) {
+                $errors->push($this->problem(
+                    'theme_entrypoint',
+                    'definition.json',
+                    "Theme {$name} must declare an existing .vibe entrypoint under resource/markup."
+                ));
+            }
+        });
+    }
+
+    private function declaredClass(array $tokens): string
+    {
+        $tokens = $this->significantTokens($tokens);
+        while (!$tokens->isEmpty()) {
+            if (!$this->tokenIs($tokens->shift(), T_CLASS)) {
+                continue;
+            }
+
+            $name = $tokens->shift();
+
+            return $this->tokenIs($name, T_STRING)
+                ? (string) Arr::make($name)->get(1)
+                : '';
+        }
+
+        return '';
+    }
+
+    private function returnsCallableFactory(array $tokens): bool
+    {
+        $tokens = $this->significantTokens($tokens);
+        $depth = 0;
+        while (!$tokens->isEmpty()) {
+            $token = $tokens->shift();
             if ($token === '{') {
                 $depth++;
                 continue;
@@ -262,19 +400,258 @@ final class AddOnContractValidator extends Service
                 $depth--;
                 continue;
             }
-            if ($returnFound) {
-                if (is_array($token) && Arr::make([T_WHITESPACE, T_COMMENT, T_DOC_COMMENT])->has($token[0], true)) {
-                    continue;
-                }
+            if ($depth !== 0 || !$this->tokenIs($token, T_RETURN)) {
+                continue;
+            }
+            if ($this->tokenIs($tokens->get(0), T_STATIC)) {
+                $tokens->shift();
+            }
 
-                return $token === '[' || (is_array($token) && $token[0] === T_ARRAY);
-            }
-            if ($depth === 0 && is_array($token) && $token[0] === T_RETURN) {
-                $returnFound = true;
-            }
+            return $this->tokenIsOneOf($tokens->shift(), [T_FN, T_FUNCTION]);
         }
 
         return false;
+    }
+
+    private function isSupportedMapping(array $tokens): bool
+    {
+        return $this->isDeclarativeMapping($tokens)
+            || $this->isExecutableMapping($tokens);
+    }
+
+    private function isDeclarativeMapping(array $tokens): bool
+    {
+        $tokens = $this->significantTokens($tokens);
+
+        if (!$this->tokenIs($tokens->shift(), T_OPEN_TAG)) {
+            return false;
+        }
+        if ($this->tokenIs($tokens->get(0), T_DECLARE)
+            && !$this->consumeStrictTypesDeclaration($tokens)
+        ) {
+            return false;
+        }
+        if (!$this->tokenIs($tokens->shift(), T_RETURN)) {
+            return false;
+        }
+
+        $opening = $tokens->shift();
+        if ($opening === '[') {
+            $delimiters = Arr::make([']']);
+        } elseif ($this->tokenIs($opening, T_ARRAY) && $tokens->shift() === '(') {
+            $delimiters = Arr::make([')']);
+        } else {
+            return false;
+        }
+
+        $closing = Arr::make([')' => true, ']' => true, '}' => true]);
+        $pairs = Arr::make(['(' => ')', '[' => ']', '{' => '}']);
+        while (!$delimiters->isEmpty()) {
+            if ($tokens->isEmpty()) {
+                return false;
+            }
+
+            $token = $tokens->shift();
+            if (Arr::is($token)) {
+                continue;
+            }
+            if ($pairs->hasKey($token)) {
+                $delimiters->push($pairs->get($token));
+                continue;
+            }
+            if ($closing->hasKey($token) && $token !== $delimiters->pop()) {
+                return false;
+            }
+        }
+
+        if ($tokens->shift() !== ';') {
+            return false;
+        }
+        if ($this->tokenIs($tokens->get(0), T_CLOSE_TAG)) {
+            $tokens->shift();
+        }
+
+        return $tokens->isEmpty();
+    }
+
+    private function isExecutableMapping(array $tokens): bool
+    {
+        $tokens = $this->significantTokens($tokens);
+        if (!$this->tokenIs($tokens->shift(), T_OPEN_TAG)) {
+            return false;
+        }
+        if ($this->tokenIs($tokens->get(0), T_DECLARE)
+            && !$this->consumeStrictTypesDeclaration($tokens)
+        ) {
+            return false;
+        }
+        if ($this->tokenIs($tokens->get(0), T_USE)
+            && !$this->consumeMappingImport($tokens)
+        ) {
+            return false;
+        }
+
+        $statements = 0;
+        while (!$tokens->isEmpty() && !$this->tokenIs($tokens->get(0), T_CLOSE_TAG)) {
+            if (!$this->consumeMappingStatement($tokens)) {
+                return false;
+            }
+            $statements++;
+        }
+        if ($this->tokenIs($tokens->get(0), T_CLOSE_TAG)) {
+            $tokens->shift();
+        }
+
+        return $statements > 0 && $tokens->isEmpty();
+    }
+
+    private function consumeMappingImport(Arr $tokens): bool
+    {
+        if (!$this->tokenIs($tokens->shift(), T_USE)) {
+            return false;
+        }
+
+        $name = $tokens->shift();
+
+        return $this->tokenIsOneOf($name, [T_NAME_QUALIFIED, T_STRING])
+            && Arr::make($name)->get(1) === 'BlueFission\\Services\\Mapping'
+            && $tokens->shift() === ';';
+    }
+
+    private function consumeMappingStatement(Arr $tokens): bool
+    {
+        $class = $tokens->shift();
+        if (!$this->tokenIsOneOf($class, [T_STRING, T_NAME_QUALIFIED])
+            || !Arr::make(['Mapping', 'BlueFission\\Services\\Mapping'])->has(
+                Arr::make($class)->get(1),
+                true
+            )
+            || !$this->tokenIs($tokens->shift(), T_DOUBLE_COLON)
+        ) {
+            return false;
+        }
+
+        $method = $tokens->shift();
+        if (!$this->tokenIs($method, T_STRING)
+            || !Arr::make(['add', 'crud'])->has(Arr::make($method)->get(1), true)
+            || $tokens->shift() !== '('
+        ) {
+            return false;
+        }
+
+        $delimiters = Arr::make([')']);
+        $pairs = Arr::make(['(' => ')', '[' => ']', '{' => '}']);
+        $closings = Arr::make([')' => true, ']' => true, '}' => true]);
+        $allowed = Arr::make([
+            T_ARRAY,
+            T_CLASS,
+            T_CONSTANT_ENCAPSED_STRING,
+            T_DNUMBER,
+            T_DOUBLE_ARROW,
+            T_DOUBLE_COLON,
+            T_LNUMBER,
+            T_NAME_QUALIFIED,
+            T_NS_SEPARATOR,
+            T_OBJECT_OPERATOR,
+            T_STRING,
+        ]);
+
+        while (!$delimiters->isEmpty()) {
+            if ($tokens->isEmpty()) {
+                return false;
+            }
+            $token = $tokens->shift();
+            if (Arr::is($token)) {
+                if (!$allowed->has(Arr::make($token)->get(0), true)) {
+                    return false;
+                }
+                continue;
+            }
+            if ($pairs->hasKey($token)) {
+                $delimiters->push($pairs->get($token));
+                continue;
+            }
+            if ($closings->hasKey($token) && $token !== $delimiters->pop()) {
+                return false;
+            }
+        }
+
+        while ($this->tokenIs($tokens->get(0), T_OBJECT_OPERATOR)) {
+            $tokens->shift();
+            if (!$this->tokenIs($tokens->shift(), T_STRING)
+                || $tokens->shift() !== '('
+            ) {
+                return false;
+            }
+            $delimiters = Arr::make([')']);
+            while (!$delimiters->isEmpty()) {
+                if ($tokens->isEmpty()) {
+                    return false;
+                }
+                $token = $tokens->shift();
+                if (Arr::is($token)) {
+                    if (!$allowed->has(Arr::make($token)->get(0), true)) {
+                        return false;
+                    }
+                    continue;
+                }
+                if ($pairs->hasKey($token)) {
+                    $delimiters->push($pairs->get($token));
+                    continue;
+                }
+                if ($closings->hasKey($token) && $token !== $delimiters->pop()) {
+                    return false;
+                }
+            }
+        }
+
+        return $tokens->shift() === ';';
+    }
+
+    private function significantTokens(array $tokens): Arr
+    {
+        return Arr::make($tokens)
+            ->filter(fn ($token): bool => !$this->tokenIsOneOf(
+                $token,
+                [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT]
+            ))
+            ->values();
+    }
+
+    private function consumeStrictTypesDeclaration(Arr $tokens): bool
+    {
+        if (!$this->tokenIs($tokens->shift(), T_DECLARE)
+            || $tokens->shift() !== '('
+        ) {
+            return false;
+        }
+
+        $name = $tokens->shift();
+        $value = null;
+        if (!$this->tokenIs($name, T_STRING)
+            || Arr::make($name)->get(1) !== 'strict_types'
+            || $tokens->shift() !== '='
+        ) {
+            return false;
+        }
+
+        $value = $tokens->shift();
+
+        return $this->tokenIs($value, T_LNUMBER)
+            && Arr::make($value)->get(1) === '1'
+            && $tokens->shift() === ')'
+            && $tokens->shift() === ';';
+    }
+
+    private function tokenIs($token, int $type): bool
+    {
+        return Arr::is($token) && Arr::make($token)->get(0) === $type;
+    }
+
+    private function tokenIsOneOf($token, array $types): bool
+    {
+        return Arr::is($token)
+            && Arr::make($types)->has(Arr::make($token)->get(0), true);
     }
 
     private function files(string $root, string $extension): array
@@ -317,7 +694,11 @@ final class AddOnContractValidator extends Service
 
     private function problem(string $code, string $path, string $message): array
     {
-        return compact('code', 'path', 'message');
+        return Arr::make([
+            'code' => $code,
+            'path' => $path,
+            'message' => $message,
+        ])->val();
     }
 
     private function path(string $root, string $relative): string
@@ -329,7 +710,7 @@ final class AddOnContractValidator extends Service
 
     private function relative(string $root, string $path): string
     {
-        return Str::make(substr($path, strlen($root)))
+        return Str::make(Str::sub($path, Str::len($root)))
             ->trim('/\\')
             ->replace('\\', '/')
             ->val();

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -361,11 +361,11 @@ final class AddOnContractValidator extends Service
             return;
         }
 
-        if (!$this->returnsCallableFactory($tokens)) {
+        if (!$this->returnsCallableFactory($tokens, (string) $class)) {
             $errors->push($this->problem(
                 'registration_factory',
                 (string) $factory,
-                'Registration factory must return a callable.'
+                'Registration factory must return a callable that constructs the configured class.'
             ));
         }
     }
@@ -429,9 +429,10 @@ final class AddOnContractValidator extends Service
         return '';
     }
 
-    private function returnsCallableFactory(array $tokens): bool
+    private function returnsCallableFactory(array $tokens, string $class): bool
     {
         $tokens = $this->significantTokens($tokens);
+        $hasClassImport = $this->hasFactoryClassImport($tokens, $class);
         $depth = 0;
         while (!$tokens->isEmpty()) {
             $token = $tokens->shift();
@@ -452,10 +453,10 @@ final class AddOnContractValidator extends Service
 
             $callable = $tokens->shift();
             if ($this->tokenIs($callable, T_FN)) {
-                return $this->consumeArrowFactory($tokens);
+                return $this->consumeArrowFactory($tokens, $class, $hasClassImport);
             }
             if ($this->tokenIs($callable, T_FUNCTION)) {
-                return $this->consumeTraditionalFactory($tokens);
+                return $this->consumeTraditionalFactory($tokens, $class, $hasClassImport);
             }
 
             return false;
@@ -464,55 +465,62 @@ final class AddOnContractValidator extends Service
         return false;
     }
 
-    private function consumeArrowFactory(Arr $tokens): bool
+    private function hasFactoryClassImport(Arr $tokens, string $class): bool
     {
-        $delimiters = Arr::make([]);
-        $pairs = Arr::make(['(' => ')', '[' => ']', '{' => '}']);
-        $closings = Arr::make([')' => true, ']' => true, '}' => true]);
-        while (!$tokens->isEmpty()) {
-            $token = $tokens->shift();
-            if (Arr::is($token)) {
-                continue;
-            }
-            if ($pairs->hasKey($token)) {
-                $delimiters->push($pairs->get($token));
-                continue;
-            }
-            if ($closings->hasKey($token)) {
-                if ($delimiters->isEmpty() || $token !== $delimiters->pop()) {
-                    return false;
-                }
-                continue;
-            }
-            if ($token === ';' && $delimiters->isEmpty()) {
-                return $this->factoryRemainderIsEmpty($tokens);
+        foreach ($tokens as $index => $token) {
+            if ($this->tokenIs($token, T_USE)
+                && $this->factoryClassTokenIs($tokens->get($index + 1), $class, false)
+            ) {
+                return true;
             }
         }
 
         return false;
     }
 
-    private function consumeTraditionalFactory(Arr $tokens): bool
+    private function consumeArrowFactory(Arr $tokens, string $class, bool $hasClassImport): bool
     {
-        $bodyDepth = 0;
-        $bodyStarted = false;
-        while (!$tokens->isEmpty()) {
-            $token = $tokens->shift();
-            if ($token === '{') {
-                $bodyStarted = true;
-                $bodyDepth++;
-                continue;
-            }
-            if ($token === '}' && $bodyStarted) {
-                $bodyDepth--;
-                if ($bodyDepth === 0) {
-                    return $tokens->shift() === ';'
-                        && $this->factoryRemainderIsEmpty($tokens);
-                }
-            }
+        return $tokens->shift() === '('
+            && $tokens->shift() === ')'
+            && $tokens->shift() === ':'
+            && $this->factoryClassTokenIs($tokens->shift(), $class, $hasClassImport)
+            && $this->tokenIs($tokens->shift(), T_DOUBLE_ARROW)
+            && $this->tokenIs($tokens->shift(), T_NEW)
+            && $this->factoryClassTokenIs($tokens->shift(), $class, $hasClassImport)
+            && $tokens->shift() === '('
+            && $tokens->shift() === ')'
+            && $tokens->shift() === ';'
+            && $this->factoryRemainderIsEmpty($tokens);
+    }
+
+    private function consumeTraditionalFactory(Arr $tokens, string $class, bool $hasClassImport): bool
+    {
+        return $tokens->shift() === '('
+            && $tokens->shift() === ')'
+            && $tokens->shift() === ':'
+            && $this->factoryClassTokenIs($tokens->shift(), $class, $hasClassImport)
+            && $tokens->shift() === '{'
+            && $this->tokenIs($tokens->shift(), T_RETURN)
+            && $this->tokenIs($tokens->shift(), T_NEW)
+            && $this->factoryClassTokenIs($tokens->shift(), $class, $hasClassImport)
+            && $tokens->shift() === '('
+            && $tokens->shift() === ')'
+            && $tokens->shift() === ';'
+            && $tokens->shift() === '}'
+            && $tokens->shift() === ';'
+            && $this->factoryRemainderIsEmpty($tokens);
+    }
+
+    private function factoryClassTokenIs($token, string $class, bool $hasClassImport): bool
+    {
+        if (!$this->isCallableNameToken($token)) {
+            return false;
         }
 
-        return false;
+        $name = Str::make((string) Arr::make($token)->get(1))->trim('\\')->val();
+        $shortName = Str::make($class)->split('\\')->pop();
+
+        return $name === $class || ($hasClassImport && $name === $shortName);
     }
 
     private function factoryRemainderIsEmpty(Arr $tokens): bool
@@ -573,7 +581,7 @@ final class AddOnContractValidator extends Service
         $closing = Arr::make([')' => true, ']' => true, '}' => true]);
         $pairs = Arr::make(['(' => ')', '[' => ']', '{' => '}']);
         $callableBodyDepth = 0;
-        $waitingForCallableBody = false;
+        $pendingCallableBodies = 0;
         $arrowClosureLevel = null;
         $closedCallableExpression = false;
         $previousToken = null;
@@ -587,7 +595,7 @@ final class AddOnContractValidator extends Service
                 return false;
             }
             if ($callableBodyDepth === 0
-                && !$waitingForCallableBody
+                && $pendingCallableBodies === 0
                 && $arrowClosureLevel === null
                 && $token === '('
                 && $this->tokenCanBeInvoked($previousToken)
@@ -600,11 +608,11 @@ final class AddOnContractValidator extends Service
             if (Arr::is($token)) {
                 $type = Arr::make($token)->get(0);
                 if ($type === T_FUNCTION) {
-                    $waitingForCallableBody = true;
-                } elseif ($type === T_FN) {
+                    $pendingCallableBodies++;
+                } elseif ($type === T_FN && $callableBodyDepth === 0) {
                     $arrowClosureLevel = $delimiters->count();
                 } elseif ($callableBodyDepth === 0
-                    && !$waitingForCallableBody
+                    && $pendingCallableBodies === 0
                     && $arrowClosureLevel === null
                     && !$this->isSafeDeclarativeToken($token, $previousToken, $tokens)
                 ) {
@@ -617,7 +625,7 @@ final class AddOnContractValidator extends Service
                 $arrowClosureLevel = null;
             }
             if ($callableBodyDepth === 0
-                && !$waitingForCallableBody
+                && $pendingCallableBodies === 0
                 && $arrowClosureLevel === null
                 && !Arr::make(['(', ')', '[', ']', ','])->has($token, true)
             ) {
@@ -626,9 +634,9 @@ final class AddOnContractValidator extends Service
             if ($pairs->hasKey($token)) {
                 $delimiters->push($pairs->get($token));
                 if ($token === '{') {
-                    if ($waitingForCallableBody) {
-                        $waitingForCallableBody = false;
-                        $callableBodyDepth = 1;
+                    if ($pendingCallableBodies > 0) {
+                        $pendingCallableBodies--;
+                        $callableBodyDepth++;
                     } elseif ($callableBodyDepth > 0) {
                         $callableBodyDepth++;
                     }
@@ -654,7 +662,7 @@ final class AddOnContractValidator extends Service
             $previousToken = $token;
         }
 
-        return !$waitingForCallableBody
+        return $pendingCallableBodies === 0
             && $callableBodyDepth === 0
             && $arrowClosureLevel === null;
     }
@@ -845,6 +853,7 @@ final class AddOnContractValidator extends Service
         }
         if ($this->tokenTextIs($token, 'class')
             && $this->tokenIs($previousToken, T_DOUBLE_COLON)
+            && $tokens->get(0) !== '('
         ) {
             return true;
         }

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -433,36 +433,100 @@ final class AddOnContractValidator extends Service
     {
         $tokens = $this->significantTokens($tokens);
         $importedClassName = $this->factoryClassImportName($tokens, $class);
-        $depth = 0;
-        while (!$tokens->isEmpty()) {
-            $token = $tokens->shift();
-            if ($token === '{') {
-                $depth++;
-                continue;
-            }
-            if ($token === '}') {
-                $depth--;
-                continue;
-            }
-            if ($depth !== 0 || !$this->tokenIs($token, T_RETURN)) {
-                continue;
-            }
-            if ($this->tokenIs($tokens->get(0), T_STATIC)) {
-                $tokens->shift();
-            }
-
-            $callable = $tokens->shift();
-            if ($this->tokenIs($callable, T_FN)) {
-                return $this->consumeArrowFactory($tokens, $class, $importedClassName);
-            }
-            if ($this->tokenIs($callable, T_FUNCTION)) {
-                return $this->consumeTraditionalFactory($tokens, $class, $importedClassName);
-            }
-
+        if (!$this->tokenIs($tokens->shift(), T_OPEN_TAG)) {
             return false;
+        }
+        if ($this->tokenIs($tokens->get(0), T_DECLARE)
+            && !$this->consumeStrictTypesDeclaration($tokens)
+        ) {
+            return false;
+        }
+        while ($this->tokenIs($tokens->get(0), T_USE)) {
+            if (!$this->consumeFactoryImport($tokens)) {
+                return false;
+            }
+        }
+        while ($this->tokenIs($tokens->get(0), T_FUNCTION)) {
+            if (!$this->consumeDeferredNamedFunction($tokens)) {
+                return false;
+            }
+        }
+        if (!$this->tokenIs($tokens->shift(), T_RETURN)) {
+            return false;
+        }
+        if ($this->tokenIs($tokens->get(0), T_STATIC)) {
+            $tokens->shift();
+        }
+
+        $callable = $tokens->shift();
+        if ($this->tokenIs($callable, T_FN)) {
+            return $this->consumeArrowFactory($tokens, $class, $importedClassName);
+        }
+        if ($this->tokenIs($callable, T_FUNCTION)) {
+            return $this->consumeTraditionalFactory($tokens, $class, $importedClassName);
         }
 
         return false;
+    }
+
+    private function consumeFactoryImport(Arr $tokens): bool
+    {
+        if (!$this->tokenIs($tokens->shift(), T_USE)
+            || !$this->isCallableNameToken($tokens->shift())
+        ) {
+            return false;
+        }
+        if ($this->tokenIs($tokens->get(0), T_AS)) {
+            $tokens->shift();
+            if (!$this->tokenIs($tokens->shift(), T_STRING)) {
+                return false;
+            }
+        }
+
+        return $tokens->shift() === ';';
+    }
+
+    private function consumeDeferredNamedFunction(Arr $tokens): bool
+    {
+        if (!$this->tokenIs($tokens->shift(), T_FUNCTION)
+            || !$this->tokenIs($tokens->shift(), T_STRING)
+        ) {
+            return false;
+        }
+
+        $signatureDepth = 0;
+        while (!$tokens->isEmpty()) {
+            $token = $tokens->shift();
+            if ($token === '(' || $token === '[') {
+                $signatureDepth++;
+                continue;
+            }
+            if ($token === ')' || $token === ']') {
+                $signatureDepth--;
+                if ($signatureDepth < 0) {
+                    return false;
+                }
+                continue;
+            }
+            if ($token === '{' && $signatureDepth === 0) {
+                break;
+            }
+            if ($token === ';' && $signatureDepth === 0) {
+                return false;
+            }
+        }
+
+        $bodyDepth = 1;
+        while (!$tokens->isEmpty() && $bodyDepth > 0) {
+            $token = $tokens->shift();
+            if ($token === '{') {
+                $bodyDepth++;
+            } elseif ($token === '}') {
+                $bodyDepth--;
+            }
+        }
+
+        return $signatureDepth === 0 && $bodyDepth === 0;
     }
 
     private function factoryClassImportName(Arr $tokens, string $class): ?string

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -517,8 +517,20 @@ final class AddOnContractValidator extends Service
         }
 
         $bodyDepth = 1;
+        $interpolationDepth = 0;
         while (!$tokens->isEmpty() && $bodyDepth > 0) {
             $token = $tokens->shift();
+            if (Arr::is($token)) {
+                $type = Arr::make($token)->get(0);
+                if ($type === T_CURLY_OPEN || $type === T_DOLLAR_OPEN_CURLY_BRACES) {
+                    $interpolationDepth++;
+                }
+                continue;
+            }
+            if ($token === '}' && $interpolationDepth > 0) {
+                $interpolationDepth--;
+                continue;
+            }
             if ($token === '{') {
                 $bodyDepth++;
             } elseif ($token === '}') {
@@ -526,13 +538,27 @@ final class AddOnContractValidator extends Service
             }
         }
 
-        return $signatureDepth === 0 && $bodyDepth === 0;
+        return $signatureDepth === 0
+            && $bodyDepth === 0
+            && $interpolationDepth === 0;
     }
 
     private function factoryClassImportName(Arr $tokens, string $class): ?string
     {
         $structuralDepth = 0;
+        $interpolationDepth = 0;
         foreach ($tokens as $index => $token) {
+            if (Arr::is($token)) {
+                $type = Arr::make($token)->get(0);
+                if ($type === T_CURLY_OPEN || $type === T_DOLLAR_OPEN_CURLY_BRACES) {
+                    $interpolationDepth++;
+                    continue;
+                }
+            }
+            if ($token === '}' && $interpolationDepth > 0) {
+                $interpolationDepth--;
+                continue;
+            }
             if ($token === '{') {
                 $structuralDepth++;
                 continue;

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -669,6 +669,7 @@ final class AddOnContractValidator extends Service
         $callableBodyDepth = 0;
         $pendingCallableBodies = 0;
         $arrowClosureLevels = Arr::make([]);
+        $interpolationDepth = 0;
         $closedCallableExpression = false;
         $previousToken = null;
         while (!$delimiters->isEmpty()) {
@@ -693,7 +694,11 @@ final class AddOnContractValidator extends Service
             }
             if (Arr::is($token)) {
                 $type = Arr::make($token)->get(0);
-                if ($type === T_FUNCTION) {
+                if (($type === T_CURLY_OPEN || $type === T_DOLLAR_OPEN_CURLY_BRACES)
+                    && ($callableBodyDepth > 0 || $arrowClosureLevels->isNotEmpty())
+                ) {
+                    $interpolationDepth++;
+                } elseif ($type === T_FUNCTION) {
                     $pendingCallableBodies++;
                 } elseif ($type === T_FN && $callableBodyDepth === 0) {
                     $arrowClosureLevels->push($delimiters->count());
@@ -704,6 +709,11 @@ final class AddOnContractValidator extends Service
                 ) {
                     return false;
                 }
+                $previousToken = $token;
+                continue;
+            }
+            if ($token === '}' && $interpolationDepth > 0) {
+                $interpolationDepth--;
                 $previousToken = $token;
                 continue;
             }
@@ -763,7 +773,8 @@ final class AddOnContractValidator extends Service
 
         return $pendingCallableBodies === 0
             && $callableBodyDepth === 0
-            && $arrowClosureLevels->isEmpty();
+            && $arrowClosureLevels->isEmpty()
+            && $interpolationDepth === 0;
     }
 
     private function isExecutableMapping(array $tokens): bool

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -553,7 +553,15 @@ final class AddOnContractValidator extends Service
 
     private function classHasPublicDefaultConstructor(Arr $tokens): bool
     {
-        while (!$tokens->isEmpty() && $tokens->shift() !== '{') {
+        $inheritsConstructor = false;
+        while (!$tokens->isEmpty()) {
+            $token = $tokens->shift();
+            if ($this->tokenIs($token, T_EXTENDS)) {
+                $inheritsConstructor = true;
+            }
+            if ($token === '{') {
+                break;
+            }
         }
         if ($tokens->isEmpty()) {
             return false;
@@ -608,7 +616,7 @@ final class AddOnContractValidator extends Service
                 && $this->constructorAllowsNoArguments($tokens);
         }
 
-        return true;
+        return !$inheritsConstructor;
     }
 
     private function constructorAllowsNoArguments(Arr $tokens): bool

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -446,6 +446,21 @@ final class AddOnContractValidator extends Service
 
         $closing = Arr::make([')' => true, ']' => true, '}' => true]);
         $pairs = Arr::make(['(' => ')', '[' => ']', '{' => '}']);
+        $callableBodyDepth = 0;
+        $waitingForCallableBody = false;
+        $disallowed = Arr::make([
+            T_EVAL,
+            T_EXIT,
+            T_FN,
+            T_INCLUDE,
+            T_INCLUDE_ONCE,
+            T_NEW,
+            T_REQUIRE,
+            T_REQUIRE_ONCE,
+            T_VARIABLE,
+            T_YIELD,
+            T_YIELD_FROM,
+        ]);
         while (!$delimiters->isEmpty()) {
             if ($tokens->isEmpty()) {
                 return false;
@@ -453,18 +468,41 @@ final class AddOnContractValidator extends Service
 
             $token = $tokens->shift();
             if (Arr::is($token)) {
+                $type = Arr::make($token)->get(0);
+                if ($type === T_FUNCTION) {
+                    $waitingForCallableBody = true;
+                } elseif ($callableBodyDepth === 0
+                    && !$waitingForCallableBody
+                    && ($disallowed->has($type, true)
+                        || ($type === T_STRING && $tokens->get(0) === '('))
+                ) {
+                    return false;
+                }
                 continue;
             }
             if ($pairs->hasKey($token)) {
                 $delimiters->push($pairs->get($token));
+                if ($token === '{') {
+                    if ($waitingForCallableBody) {
+                        $waitingForCallableBody = false;
+                        $callableBodyDepth = 1;
+                    } elseif ($callableBodyDepth > 0) {
+                        $callableBodyDepth++;
+                    }
+                }
                 continue;
             }
-            if ($closing->hasKey($token) && $token !== $delimiters->pop()) {
-                return false;
+            if ($closing->hasKey($token)) {
+                if ($token === '}' && $callableBodyDepth > 0) {
+                    $callableBodyDepth--;
+                }
+                if ($token !== $delimiters->pop()) {
+                    return false;
+                }
             }
         }
 
-        if ($tokens->shift() !== ';') {
+        if ($waitingForCallableBody || $callableBodyDepth !== 0 || $tokens->shift() !== ';') {
             return false;
         }
         if ($this->tokenIs($tokens->get(0), T_CLOSE_TAG)) {
@@ -562,7 +600,10 @@ final class AddOnContractValidator extends Service
             }
             $token = $tokens->shift();
             if (Arr::is($token)) {
-                if (!$allowed->has(Arr::make($token)->get(0), true)) {
+                $type = Arr::make($token)->get(0);
+                if (!$allowed->has($type, true)
+                    || ($type === T_STRING && $tokens->get(0) === '(')
+                ) {
                     return false;
                 }
                 continue;
@@ -590,7 +631,10 @@ final class AddOnContractValidator extends Service
                 }
                 $token = $tokens->shift();
                 if (Arr::is($token)) {
-                    if (!$allowed->has(Arr::make($token)->get(0), true)) {
+                    $type = Arr::make($token)->get(0);
+                    if (!$allowed->has($type, true)
+                        || ($type === T_STRING && $tokens->get(0) === '(')
+                    ) {
                         return false;
                     }
                     continue;

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -548,13 +548,28 @@ final class AddOnContractValidator extends Service
 
         $opening = $tokens->shift();
         if ($opening === '[') {
-            $delimiters = Arr::make([']']);
+            $closingToken = ']';
         } elseif ($this->tokenIs($opening, T_ARRAY) && $tokens->shift() === '(') {
-            $delimiters = Arr::make([')']);
+            $closingToken = ')';
         } else {
             return false;
         }
 
+        if (!$this->consumeSafeValueSequence($tokens, $closingToken)
+            || $tokens->shift() !== ';'
+        ) {
+            return false;
+        }
+        if ($this->tokenIs($tokens->get(0), T_CLOSE_TAG)) {
+            $tokens->shift();
+        }
+
+        return $tokens->isEmpty();
+    }
+
+    private function consumeSafeValueSequence(Arr $tokens, string $closingToken): bool
+    {
+        $delimiters = Arr::make([$closingToken]);
         $closing = Arr::make([')' => true, ']' => true, '}' => true]);
         $pairs = Arr::make(['(' => ')', '[' => ']', '{' => '}']);
         $callableBodyDepth = 0;
@@ -639,18 +654,9 @@ final class AddOnContractValidator extends Service
             $previousToken = $token;
         }
 
-        if ($waitingForCallableBody
-            || $callableBodyDepth !== 0
-            || $arrowClosureLevel !== null
-            || $tokens->shift() !== ';'
-        ) {
-            return false;
-        }
-        if ($this->tokenIs($tokens->get(0), T_CLOSE_TAG)) {
-            $tokens->shift();
-        }
-
-        return $tokens->isEmpty();
+        return !$waitingForCallableBody
+            && $callableBodyDepth === 0
+            && $arrowClosureLevel === null;
     }
 
     private function isExecutableMapping(array $tokens): bool
@@ -664,15 +670,17 @@ final class AddOnContractValidator extends Service
         ) {
             return false;
         }
-        if ($this->tokenIs($tokens->get(0), T_USE)
-            && !$this->consumeMappingImport($tokens)
-        ) {
-            return false;
+        $hasMappingImport = false;
+        if ($this->tokenIs($tokens->get(0), T_USE)) {
+            if (!$this->consumeMappingImport($tokens)) {
+                return false;
+            }
+            $hasMappingImport = true;
         }
 
         $statements = 0;
         while (!$tokens->isEmpty() && !$this->tokenIs($tokens->get(0), T_CLOSE_TAG)) {
-            if (!$this->consumeMappingStatement($tokens)) {
+            if (!$this->consumeMappingStatement($tokens, $hasMappingImport)) {
                 return false;
             }
             $statements++;
@@ -697,14 +705,15 @@ final class AddOnContractValidator extends Service
             && $tokens->shift() === ';';
     }
 
-    private function consumeMappingStatement(Arr $tokens): bool
+    private function consumeMappingStatement(Arr $tokens, bool $hasMappingImport): bool
     {
         $class = $tokens->shift();
-        if (!$this->tokenIsOneOf($class, [T_STRING, T_NAME_QUALIFIED])
-            || !Arr::make(['Mapping', 'BlueFission\\Services\\Mapping'])->has(
-                Arr::make($class)->get(1),
-                true
-            )
+        if (!$this->tokenIsOneOf($class, [T_STRING, T_NAME_FULLY_QUALIFIED, T_NAME_QUALIFIED])) {
+            return false;
+        }
+        $className = Str::make((string) Arr::make($class)->get(1))->trim('\\')->val();
+        if (($className === 'Mapping' && !$hasMappingImport)
+            || !Arr::make(['Mapping', 'BlueFission\\Services\\Mapping'])->has($className, true)
             || !$this->tokenIs($tokens->shift(), T_DOUBLE_COLON)
         ) {
             return false;
@@ -739,45 +748,7 @@ final class AddOnContractValidator extends Service
 
     private function consumeSafeMappingArguments(Arr $tokens): bool
     {
-        $delimiters = Arr::make([')']);
-        $pairs = Arr::make(['(' => ')', '[' => ']']);
-        $closings = Arr::make([')' => true, ']' => true]);
-        $previousToken = null;
-        while (!$delimiters->isEmpty()) {
-            if ($tokens->isEmpty()) {
-                return false;
-            }
-
-            $token = $tokens->shift();
-            if (Arr::is($token)) {
-                if (!$this->isSafeDeclarativeToken($token, $previousToken, $tokens)) {
-                    return false;
-                }
-                $previousToken = $token;
-                continue;
-            }
-            if ($token === '(' && $this->tokenCanBeInvoked($previousToken)) {
-                return false;
-            }
-            if ($pairs->hasKey($token)) {
-                $delimiters->push($pairs->get($token));
-                $previousToken = $token;
-                continue;
-            }
-            if ($closings->hasKey($token)) {
-                if ($token !== $delimiters->pop()) {
-                    return false;
-                }
-                $previousToken = $token;
-                continue;
-            }
-            if ($token !== ',') {
-                return false;
-            }
-            $previousToken = $token;
-        }
-
-        return true;
+        return $this->consumeSafeValueSequence($tokens, ')');
     }
 
     private function significantTokens(array $tokens): Arr

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -432,7 +432,7 @@ final class AddOnContractValidator extends Service
     private function returnsCallableFactory(array $tokens, string $class): bool
     {
         $tokens = $this->significantTokens($tokens);
-        $hasClassImport = $this->hasFactoryClassImport($tokens, $class);
+        $importedClassName = $this->factoryClassImportName($tokens, $class);
         $depth = 0;
         while (!$tokens->isEmpty()) {
             $token = $tokens->shift();
@@ -453,10 +453,10 @@ final class AddOnContractValidator extends Service
 
             $callable = $tokens->shift();
             if ($this->tokenIs($callable, T_FN)) {
-                return $this->consumeArrowFactory($tokens, $class, $hasClassImport);
+                return $this->consumeArrowFactory($tokens, $class, $importedClassName);
             }
             if ($this->tokenIs($callable, T_FUNCTION)) {
-                return $this->consumeTraditionalFactory($tokens, $class, $hasClassImport);
+                return $this->consumeTraditionalFactory($tokens, $class, $importedClassName);
             }
 
             return false;
@@ -465,44 +465,53 @@ final class AddOnContractValidator extends Service
         return false;
     }
 
-    private function hasFactoryClassImport(Arr $tokens, string $class): bool
+    private function factoryClassImportName(Arr $tokens, string $class): ?string
     {
         foreach ($tokens as $index => $token) {
             if ($this->tokenIs($token, T_USE)
-                && $this->factoryClassTokenIs($tokens->get($index + 1), $class, false)
+                && $this->factoryClassTokenIs($tokens->get($index + 1), $class, null)
             ) {
-                return true;
+                $next = $tokens->get($index + 2);
+                if ($next === ';') {
+                    return (string) Str::make($class)->split('\\')->pop();
+                }
+                if ($this->tokenIs($next, T_AS)
+                    && $this->tokenIs($tokens->get($index + 3), T_STRING)
+                    && $tokens->get($index + 4) === ';'
+                ) {
+                    return (string) Arr::make($tokens->get($index + 3))->get(1);
+                }
             }
         }
 
-        return false;
+        return null;
     }
 
-    private function consumeArrowFactory(Arr $tokens, string $class, bool $hasClassImport): bool
+    private function consumeArrowFactory(Arr $tokens, string $class, ?string $importedClassName): bool
     {
         return $tokens->shift() === '('
             && $tokens->shift() === ')'
             && $tokens->shift() === ':'
-            && $this->factoryClassTokenIs($tokens->shift(), $class, $hasClassImport)
+            && $this->factoryClassTokenIs($tokens->shift(), $class, $importedClassName)
             && $this->tokenIs($tokens->shift(), T_DOUBLE_ARROW)
             && $this->tokenIs($tokens->shift(), T_NEW)
-            && $this->factoryClassTokenIs($tokens->shift(), $class, $hasClassImport)
+            && $this->factoryClassTokenIs($tokens->shift(), $class, $importedClassName)
             && $tokens->shift() === '('
             && $tokens->shift() === ')'
             && $tokens->shift() === ';'
             && $this->factoryRemainderIsEmpty($tokens);
     }
 
-    private function consumeTraditionalFactory(Arr $tokens, string $class, bool $hasClassImport): bool
+    private function consumeTraditionalFactory(Arr $tokens, string $class, ?string $importedClassName): bool
     {
         return $tokens->shift() === '('
             && $tokens->shift() === ')'
             && $tokens->shift() === ':'
-            && $this->factoryClassTokenIs($tokens->shift(), $class, $hasClassImport)
+            && $this->factoryClassTokenIs($tokens->shift(), $class, $importedClassName)
             && $tokens->shift() === '{'
             && $this->tokenIs($tokens->shift(), T_RETURN)
             && $this->tokenIs($tokens->shift(), T_NEW)
-            && $this->factoryClassTokenIs($tokens->shift(), $class, $hasClassImport)
+            && $this->factoryClassTokenIs($tokens->shift(), $class, $importedClassName)
             && $tokens->shift() === '('
             && $tokens->shift() === ')'
             && $tokens->shift() === ';'
@@ -511,16 +520,14 @@ final class AddOnContractValidator extends Service
             && $this->factoryRemainderIsEmpty($tokens);
     }
 
-    private function factoryClassTokenIs($token, string $class, bool $hasClassImport): bool
+    private function factoryClassTokenIs($token, string $class, ?string $importedClassName): bool
     {
         if (!$this->isCallableNameToken($token)) {
             return false;
         }
 
         $name = Str::make((string) Arr::make($token)->get(1))->trim('\\')->val();
-        $shortName = Str::make($class)->split('\\')->pop();
-
-        return $name === $class || ($hasClassImport && $name === $shortName);
+        return $name === $class || (Str::is($importedClassName) && $name === $importedClassName);
     }
 
     private function factoryRemainderIsEmpty(Arr $tokens): bool
@@ -582,7 +589,7 @@ final class AddOnContractValidator extends Service
         $pairs = Arr::make(['(' => ')', '[' => ']', '{' => '}']);
         $callableBodyDepth = 0;
         $pendingCallableBodies = 0;
-        $arrowClosureLevel = null;
+        $arrowClosureLevels = Arr::make([]);
         $closedCallableExpression = false;
         $previousToken = null;
         while (!$delimiters->isEmpty()) {
@@ -596,7 +603,7 @@ final class AddOnContractValidator extends Service
             }
             if ($callableBodyDepth === 0
                 && $pendingCallableBodies === 0
-                && $arrowClosureLevel === null
+                && $arrowClosureLevels->isEmpty()
                 && $token === '('
                 && $this->tokenCanBeInvoked($previousToken)
             ) {
@@ -610,10 +617,10 @@ final class AddOnContractValidator extends Service
                 if ($type === T_FUNCTION) {
                     $pendingCallableBodies++;
                 } elseif ($type === T_FN && $callableBodyDepth === 0) {
-                    $arrowClosureLevel = $delimiters->count();
+                    $arrowClosureLevels->push($delimiters->count());
                 } elseif ($callableBodyDepth === 0
                     && $pendingCallableBodies === 0
-                    && $arrowClosureLevel === null
+                    && $arrowClosureLevels->isEmpty()
                     && !$this->isSafeDeclarativeToken($token, $previousToken, $tokens)
                 ) {
                     return false;
@@ -621,12 +628,15 @@ final class AddOnContractValidator extends Service
                 $previousToken = $token;
                 continue;
             }
-            if ($token === ',' && $arrowClosureLevel === $delimiters->count()) {
-                $arrowClosureLevel = null;
+            if ($token === ','
+                && $arrowClosureLevels->isNotEmpty()
+                && $arrowClosureLevels->get($arrowClosureLevels->count() - 1) === $delimiters->count()
+            ) {
+                $arrowClosureLevels->pop();
             }
             if ($callableBodyDepth === 0
                 && $pendingCallableBodies === 0
-                && $arrowClosureLevel === null
+                && $arrowClosureLevels->isEmpty()
                 && !Arr::make(['(', ')', '[', ']', ','])->has($token, true)
             ) {
                 return false;
@@ -645,13 +655,15 @@ final class AddOnContractValidator extends Service
                 continue;
             }
             if ($closing->hasKey($token)) {
-                if ($arrowClosureLevel === $delimiters->count()) {
-                    $arrowClosureLevel = null;
-                    $closedCallableExpression = true;
+                if ($arrowClosureLevels->isNotEmpty()
+                    && $arrowClosureLevels->get($arrowClosureLevels->count() - 1) === $delimiters->count()
+                ) {
+                    $arrowClosureLevels->pop();
+                    $closedCallableExpression = $arrowClosureLevels->isEmpty();
                 }
                 if ($token === '}' && $callableBodyDepth > 0) {
                     $callableBodyDepth--;
-                    if ($callableBodyDepth === 0) {
+                    if ($callableBodyDepth === 0 && $arrowClosureLevels->isEmpty()) {
                         $closedCallableExpression = true;
                     }
                 }
@@ -664,7 +676,7 @@ final class AddOnContractValidator extends Service
 
         return $pendingCallableBodies === 0
             && $callableBodyDepth === 0
-            && $arrowClosureLevel === null;
+            && $arrowClosureLevels->isEmpty();
     }
 
     private function isExecutableMapping(array $tokens): bool

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -561,9 +561,15 @@ final class AddOnContractValidator extends Service
 
     private function consumeFactoryImport(Arr $tokens): bool
     {
-        if (!$this->tokenIs($tokens->shift(), T_USE)
-            || !$this->isCallableNameToken($tokens->shift())
+        if (!$this->tokenIs($tokens->shift(), T_USE)) {
+            return false;
+        }
+        if ($this->tokenIs($tokens->get(0), T_FUNCTION)
+            || $this->tokenIs($tokens->get(0), T_CONST)
         ) {
+            $tokens->shift();
+        }
+        if (!$this->isCallableNameToken($tokens->shift())) {
             return false;
         }
         if ($this->tokenIs($tokens->get(0), T_AS)) {

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -800,7 +800,7 @@ final class AddOnContractValidator extends Service
             }
 
             $token = $tokens->shift();
-            if ($closedCallableExpression && $token === '(') {
+            if ($closedCallableExpression && ($token === '(' || $token === '[')) {
                 return false;
             }
             if ($callableBodyDepth === 0

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -414,16 +414,59 @@ final class AddOnContractValidator extends Service
     private function declaredClass(array $tokens): string
     {
         $tokens = $this->significantTokens($tokens);
+        $structuralDepth = 0;
+        $namespaceDepth = 0;
+        $namespacePending = false;
+        $interpolationDepth = 0;
+        $previousToken = null;
         while (!$tokens->isEmpty()) {
-            if (!$this->tokenIs($tokens->shift(), T_CLASS)) {
+            $token = $tokens->shift();
+            if (Arr::is($token)) {
+                $type = Arr::make($token)->get(0);
+                if ($type === T_CURLY_OPEN || $type === T_DOLLAR_OPEN_CURLY_BRACES) {
+                    $interpolationDepth++;
+                    $previousToken = $token;
+                    continue;
+                }
+                if ($type === T_NAMESPACE) {
+                    $namespacePending = true;
+                    $previousToken = $token;
+                    continue;
+                }
+                if ($type !== T_CLASS
+                    || $structuralDepth !== $namespaceDepth
+                    || $this->tokenIs($previousToken, T_NEW)
+                ) {
+                    $previousToken = $token;
+                    continue;
+                }
+
+                $name = $tokens->shift();
+
+                return $this->tokenIs($name, T_STRING)
+                    ? (string) Arr::make($name)->get(1)
+                    : '';
+            }
+            if ($token === '}' && $interpolationDepth > 0) {
+                $interpolationDepth--;
+                $previousToken = $token;
                 continue;
             }
-
-            $name = $tokens->shift();
-
-            return $this->tokenIs($name, T_STRING)
-                ? (string) Arr::make($name)->get(1)
-                : '';
+            if ($namespacePending && ($token === ';' || $token === '{')) {
+                if ($token === '{') {
+                    $structuralDepth++;
+                }
+                $namespaceDepth = $structuralDepth;
+                $namespacePending = false;
+                $previousToken = $token;
+                continue;
+            }
+            if ($token === '{') {
+                $structuralDepth++;
+            } elseif ($token === '}') {
+                $structuralDepth--;
+            }
+            $previousToken = $token;
         }
 
         return '';

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -100,6 +100,17 @@ final class AddOnContractValidator extends Service
         if ($composer->get('type') !== 'opus-addon') {
             $errors->push($this->problem('composer_type', 'composer.json', 'Composer type must be opus-addon.'));
         }
+        if (!Str::is($composer->get('name'))
+            || !Str::make($composer->get('name'))->matches(
+                '/^[a-z0-9](?:[_.-]?[a-z0-9]+)*\/[a-z0-9](?:[_.-]?[a-z0-9]+)*$/'
+            )
+        ) {
+            $errors->push($this->problem(
+                'composer_name',
+                'composer.json',
+                'Composer package name must use a valid lowercase vendor/package slug.'
+            ));
+        }
 
         $name = $definition->get('name');
         if (!Str::is($name) || !Str::make($name)->matches('/^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$/')) {
@@ -474,6 +485,7 @@ final class AddOnContractValidator extends Service
             T_INCLUDE,
             T_INCLUDE_ONCE,
             T_NEW,
+            T_PRINT,
             T_REQUIRE,
             T_REQUIRE_ONCE,
             T_VARIABLE,

--- a/app/Business/Services/AddOnContractValidator.php
+++ b/app/Business/Services/AddOnContractValidator.php
@@ -418,6 +418,25 @@ final class AddOnContractValidator extends Service
         $namespaceDepth = 0;
         $namespacePending = false;
         $interpolationDepth = 0;
+        $parenthesisDepth = 0;
+        $alternativeScopeDepth = 0;
+        $alternativeScopePending = false;
+        $alternativeOpenTokens = Arr::make([
+            T_DECLARE,
+            T_FOR,
+            T_FOREACH,
+            T_IF,
+            T_SWITCH,
+            T_WHILE,
+        ]);
+        $alternativeEndTokens = Arr::make([
+            T_ENDDECLARE,
+            T_ENDFOR,
+            T_ENDFOREACH,
+            T_ENDIF,
+            T_ENDSWITCH,
+            T_ENDWHILE,
+        ]);
         $previousToken = null;
         while (!$tokens->isEmpty()) {
             $token = $tokens->shift();
@@ -433,8 +452,20 @@ final class AddOnContractValidator extends Service
                     $previousToken = $token;
                     continue;
                 }
+                if ($alternativeOpenTokens->has($type, true)) {
+                    $alternativeScopePending = true;
+                    $previousToken = $token;
+                    continue;
+                }
+                if ($alternativeEndTokens->has($type, true)) {
+                    $alternativeScopeDepth--;
+                    $previousToken = $token;
+                    continue;
+                }
                 if ($type !== T_CLASS
                     || $structuralDepth !== $namespaceDepth
+                    || $alternativeScopeDepth !== 0
+                    || $alternativeScopePending
                     || $this->tokenIs($previousToken, T_NEW)
                 ) {
                     $previousToken = $token;
@@ -460,6 +491,22 @@ final class AddOnContractValidator extends Service
                 $namespacePending = false;
                 $previousToken = $token;
                 continue;
+            }
+            if ($token === '(') {
+                $parenthesisDepth++;
+            } elseif ($token === ')') {
+                $parenthesisDepth--;
+            }
+            if ($alternativeScopePending && $parenthesisDepth === 0) {
+                if ($token === ':') {
+                    $alternativeScopeDepth++;
+                    $alternativeScopePending = false;
+                    $previousToken = $token;
+                    continue;
+                }
+                if ($token === '{' || $token === ';') {
+                    $alternativeScopePending = false;
+                }
             }
             if ($token === '{') {
                 $structuralDepth++;

--- a/app/Business/Services/AddOnScaffoldService.php
+++ b/app/Business/Services/AddOnScaffoldService.php
@@ -1,0 +1,355 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Business\Services;
+
+use BlueFission\Arr;
+use BlueFission\Data\FileSystem;
+use BlueFission\Services\Service;
+use BlueFission\Str;
+use InvalidArgumentException;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RuntimeException;
+use Throwable;
+
+final class AddOnScaffoldService extends Service
+{
+    private AddOnContractValidator $validator;
+    private string $workspace;
+
+    public function __construct(?string $workspace = null, ?AddOnContractValidator $validator = null)
+    {
+        parent::__construct();
+
+        $workspace = $workspace ?? (defined('APP_ROOT') ? (string) constant('APP_ROOT') : dirname(__DIR__, 3));
+        $resolved = realpath($workspace);
+        if (!Str::is($resolved) || !FileSystem::directoryExists((string) $resolved)) {
+            throw new InvalidArgumentException('Application workspace could not be resolved.');
+        }
+
+        $this->workspace = (string) $resolved;
+        $this->validator = $validator ?? new AddOnContractValidator();
+    }
+
+    public function generate(string $name, string $target, ?string $namespace = null): array
+    {
+        try {
+            $name = Str::make($name)->trim()->lower()->val();
+            if (!Str::make($name)->matches('/^[a-z][a-z0-9_]*$/')) {
+                return $this->failure('name_invalid', 'Add-on name must be a lowercase lifecycle-safe key.');
+            }
+
+            $className = $this->className($name);
+            $namespace = $namespace === null ? "AddOns\\{$className}" : Str::make($namespace)->trim('\\')->val();
+            if (!Str::make($namespace)->matches('/^AddOns\\\\[A-Z][A-Za-z0-9]*$/')) {
+                return $this->failure('namespace_invalid', 'Namespace must use AddOns\\PackageName.');
+            }
+
+            $destination = $this->destination($target);
+            if (FileSystem::fileExists($destination) || FileSystem::directoryExists($destination)) {
+                return $this->failure('destination_exists', 'Destination already exists.');
+            }
+
+            $staging = $this->workspace . DIRECTORY_SEPARATOR . '.opus-addon-' . bin2hex(random_bytes(8));
+            $files = $this->fileMap($name, $className, $namespace);
+            $directories = $this->directories();
+            foreach ($directories as $directory) {
+                $files[$directory . '/.gitkeep'] = '';
+            }
+
+            try {
+                $this->ensureDirectory($staging);
+                foreach ($directories as $directory) {
+                    $this->ensureDirectory($staging . DIRECTORY_SEPARATOR . $this->nativePath($directory));
+                }
+                foreach ($files as $relative => $contents) {
+                    $path = $staging . DIRECTORY_SEPARATOR . $this->nativePath((string) $relative);
+                    $this->ensureDirectory(dirname($path));
+                    $this->write($path, (string) $contents);
+                }
+
+                $validation = Arr::make($this->validator->validate($staging));
+                if (!$validation->get('valid')) {
+                    return [
+                        'created' => false,
+                        'path' => null,
+                        'files' => [],
+                        'errors' => $validation->get('errors'),
+                        'warnings' => $validation->get('warnings'),
+                    ];
+                }
+
+                if (!rename($staging, $destination)) {
+                    throw new RuntimeException('Generated add-on could not be published.');
+                }
+
+                return [
+                    'created' => true,
+                    'path' => $destination,
+                    'files' => array_keys($files),
+                    'errors' => [],
+                    'warnings' => $validation->get('warnings'),
+                ];
+            } finally {
+                if (FileSystem::directoryExists($staging)) {
+                    $this->removeDirectory($staging);
+                }
+            }
+        } catch (Throwable $exception) {
+            return $this->failure('generation_failed', $exception->getMessage());
+        }
+    }
+
+    private function fileMap(string $name, string $className, string $namespace): array
+    {
+        $composer = [
+            'name' => 'bluefission/opus-addon-' . Str::replace($name, '_', '-'),
+            'description' => "{$className} capability add-on for Opus.",
+            'type' => 'opus-addon',
+            'license' => 'proprietary',
+            'require' => [
+                'php' => '^8.2',
+                'bluefission/bluecore' => '^0.1.1@alpha',
+                'bluefission/develation' => '^1.3.41',
+            ],
+            'require-dev' => ['phpunit/phpunit' => '^11.5'],
+            'autoload' => ['psr-4' => [$namespace . '\\' => 'logic/']],
+            'autoload-dev' => ['psr-4' => ['Tests\\' => 'tests/']],
+            'extra' => ['installer-name' => $name, 'opus-addon' => true],
+            'scripts' => ['test' => 'phpunit --do-not-cache-result'],
+            'minimum-stability' => 'alpha',
+            'prefer-stable' => true,
+        ];
+        $definition = [
+            'name' => $name,
+            'description' => "{$className} capability add-on.",
+            'version' => '0.1.0-alpha',
+            'namespace' => $namespace,
+            'libraries' => [],
+            'primary_file' => 'main.php',
+        ];
+
+        $registration = str_replace(
+            ['{{NAMESPACE}}'],
+            [$namespace],
+            <<<'PHP'
+<?php
+
+declare(strict_types=1);
+
+namespace {{NAMESPACE}}\Registration;
+
+final class AddOnRegistration
+{
+    public function contributions(): array
+    {
+        return [
+            'api' => require dirname(__DIR__, 2) . '/mapping/api.php',
+            'app' => require dirname(__DIR__, 2) . '/mapping/app.php',
+            'console' => require dirname(__DIR__, 2) . '/mapping/console.php',
+            'default' => require dirname(__DIR__, 2) . '/mapping/default.php',
+            'menus' => require dirname(__DIR__, 2) . '/mapping/menus.php',
+        ];
+    }
+}
+PHP
+        );
+        $main = str_replace(
+            ['{{NAME}}', '{{NAMESPACE}}'],
+            [$name, $namespace],
+            <<<'PHP'
+<?php
+
+declare(strict_types=1);
+
+use {{NAMESPACE}}\Registration\AddOnRegistration;
+
+function {{NAME}}_install(): void
+{
+}
+
+function {{NAME}}_uninstall(): void
+{
+}
+
+return static fn (): AddOnRegistration => new AddOnRegistration();
+PHP
+        );
+
+        return [
+            'composer.json' => json_encode($composer, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n",
+            'definition.json' => json_encode($definition, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n",
+            'main.php' => $main . "\n",
+            'README.md' => "# {$className}\n\n{$className} is an Opus add-on.\n",
+            'logic/Registration/AddOnRegistration.php' => $registration . "\n",
+            'mapping/api.php' => $this->mapping(),
+            'mapping/app.php' => $this->mapping(),
+            'mapping/console.php' => $this->mapping(),
+            'mapping/default.php' => $this->mapping(),
+            'mapping/menus.php' => $this->menus(),
+            'resource/markup/default.vibe' => "<section>\n  <h1>{\$title}</h1>\n</section>\n",
+            'phpunit.xml' => $this->phpunitConfiguration(),
+            'tests/bootstrap.php' => "<?php\n\ndeclare(strict_types=1);\n\nrequire dirname(__DIR__) . '/vendor/autoload.php';\n",
+        ];
+    }
+
+    private function mapping(): string
+    {
+        return "<?php\n\ndeclare(strict_types=1);\n\nreturn [];\n";
+    }
+
+    private function menus(): string
+    {
+        return <<<'PHP'
+<?php
+
+declare(strict_types=1);
+
+return [
+    'items' => [],
+    'register' => static function (?object $navigation = null): array {
+        if ($navigation === null) {
+            return [];
+        }
+
+        return [];
+    },
+];
+PHP;
+    }
+
+    private function phpunitConfiguration(): string
+    {
+        return <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         cacheDirectory=".phpunit.cache"
+         colors="true">
+    <testsuites>
+        <testsuite name="Add-on">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>
+XML;
+    }
+
+    private function directories(): array
+    {
+        return [
+            'datasources/generator',
+            'datasources/structure',
+            'logic/Business/Http',
+            'logic/Business/Managers',
+            'logic/Business/Prompts',
+            'logic/Domain/Models',
+            'logic/Domain/Queries',
+            'logic/Domain/Repositories',
+            'logic/Domain/Values',
+            'resource/src',
+        ];
+    }
+
+    private function destination(string $target): string
+    {
+        if ($target === '' || Str::make(Str::replace($target, '\\', '/'))->split('/')->has('..', true)) {
+            throw new InvalidArgumentException('Destination must not be empty or contain parent traversal.');
+        }
+
+        $candidate = $this->isAbsolute($target)
+            ? $target
+            : $this->workspace . DIRECTORY_SEPARATOR . $target;
+        $parent = realpath(dirname($candidate));
+        if (!Str::is($parent)) {
+            throw new InvalidArgumentException('Destination parent directory must exist.');
+        }
+
+        $root = $this->normalize($this->workspace) . '/';
+        $normalizedParent = $this->normalize($parent) . '/';
+        if (!Str::startsWith($normalizedParent, $root)) {
+            throw new InvalidArgumentException('Destination must stay inside the application workspace.');
+        }
+
+        return $parent . DIRECTORY_SEPARATOR . FileSystem::fileBasename($candidate);
+    }
+
+    private function ensureDirectory(string $directory): void
+    {
+        if (FileSystem::directoryExists($directory)) {
+            return;
+        }
+        if (!mkdir($directory, 0777, true) && !FileSystem::directoryExists($directory)) {
+            throw new RuntimeException("Directory could not be created: {$directory}");
+        }
+    }
+
+    private function write(string $path, string $contents): void
+    {
+        $filesystem = new FileSystem([
+            'root' => dirname($path),
+            'mode' => 'w',
+            'filter' => 'file',
+            'doNotConfirm' => true,
+        ]);
+        $filesystem->open((string) FileSystem::fileBasename($path))
+            ->contents($contents)
+            ->write()
+            ->close();
+
+        if (!FileSystem::fileExists($path)) {
+            throw new RuntimeException("File could not be written: {$path}");
+        }
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($directory, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($iterator as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($directory);
+    }
+
+    private function className(string $name): string
+    {
+        return Arr::make(Str::make($name)->split('_')->val())
+            ->map(fn (string $part): string => Str::make($part)->capitalize()->val())
+            ->join('')
+            ->val();
+    }
+
+    private function nativePath(string $path): string
+    {
+        return Str::replace($path, '/', DIRECTORY_SEPARATOR);
+    }
+
+    private function normalize(string $path): string
+    {
+        return Str::make(Str::replace($path, '\\', '/'))->trim('/')->val();
+    }
+
+    private function isAbsolute(string $path): bool
+    {
+        return Str::startsWith($path, '/')
+            || Str::startsWith($path, '\\\\')
+            || Str::make($path)->matches('/^[A-Za-z]:[\\/\\\\]/');
+    }
+
+    private function failure(string $code, string $message): array
+    {
+        return [
+            'created' => false,
+            'path' => null,
+            'files' => [],
+            'errors' => [['code' => $code, 'path' => '.', 'message' => $message]],
+            'warnings' => [],
+        ];
+    }
+}

--- a/app/Business/Services/AddOnScaffoldService.php
+++ b/app/Business/Services/AddOnScaffoldService.php
@@ -8,7 +8,6 @@ use BlueFission\Arr;
 use BlueFission\Data\FileSystem;
 use BlueFission\Services\Service;
 use BlueFission\Str;
-use DirectoryIterator;
 use InvalidArgumentException;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -346,38 +345,43 @@ PHP;
 
     private function publish(string $staging, string $destination): bool
     {
-        // Creating the destination is the atomic no-clobber claim. Contents are
-        // moved only after this process owns that directory.
-        set_error_handler(static fn (): bool => true);
-        try {
-            $reserved = mkdir($destination, 0777);
-        } finally {
-            restore_error_handler();
+        $lockPath = $this->publicationLockPath($destination);
+        $lock = fopen($lockPath, 'c');
+        if ($lock === false) {
+            throw new RuntimeException('Generated add-on publication lock could not be opened.');
         }
 
-        if (!$reserved) {
+        try {
+            if (!flock($lock, LOCK_EX | LOCK_NB)) {
+                return false;
+            }
             if (FileSystem::fileExists($destination) || FileSystem::directoryExists($destination)) {
                 return false;
             }
 
-            throw new RuntimeException('Generated add-on destination could not be reserved.');
+            // The complete staged tree becomes discoverable in one filesystem operation.
+            if (!rename($staging, $destination)) {
+                if (FileSystem::fileExists($destination) || FileSystem::directoryExists($destination)) {
+                    return false;
+                }
+
+                throw new RuntimeException('Generated add-on could not be published.');
+            }
+
+            return true;
+        } finally {
+            flock($lock, LOCK_UN);
+            fclose($lock);
         }
+    }
 
-        foreach (new DirectoryIterator($staging) as $item) {
-            if ($item->isDot()) {
-                continue;
-            }
-
-            $target = $destination . DIRECTORY_SEPARATOR . $item->getFilename();
-            if (FileSystem::fileExists($target) || FileSystem::directoryExists($target)) {
-                throw new RuntimeException('Generated add-on destination changed during publication.');
-            }
-            if (!rename($item->getPathname(), $target)) {
-                throw new RuntimeException('Generated add-on contents could not be published.');
-            }
-        }
-
-        return true;
+    private function publicationLockPath(string $destination): string
+    {
+        return sys_get_temp_dir()
+            . DIRECTORY_SEPARATOR
+            . 'opus-addon-publish-'
+            . Str::make($this->normalize($destination))->encrypt('sha1')->val()
+            . '.lock';
     }
 
     private function removeDirectory(string $directory): void

--- a/app/Business/Services/AddOnScaffoldService.php
+++ b/app/Business/Services/AddOnScaffoldService.php
@@ -8,6 +8,7 @@ use BlueFission\Arr;
 use BlueFission\Data\FileSystem;
 use BlueFission\Services\Service;
 use BlueFission\Str;
+use DirectoryIterator;
 use InvalidArgumentException;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -359,13 +360,46 @@ PHP;
                 return false;
             }
 
-            // The complete staged tree becomes discoverable in one filesystem operation.
-            if (!rename($staging, $destination)) {
+            $definition = $staging . DIRECTORY_SEPARATOR . 'definition.json';
+            if (!FileSystem::fileExists($definition)) {
+                throw new RuntimeException('Generated add-on definition is missing.');
+            }
+
+            set_error_handler(static fn (): bool => true);
+            try {
+                $reserved = mkdir($destination, 0777);
+            } finally {
+                restore_error_handler();
+            }
+            if (!$reserved) {
                 if (FileSystem::fileExists($destination) || FileSystem::directoryExists($destination)) {
                     return false;
                 }
 
-                throw new RuntimeException('Generated add-on could not be published.');
+                throw new RuntimeException('Generated add-on destination could not be reserved.');
+            }
+
+            try {
+                foreach (new DirectoryIterator($staging) as $item) {
+                    if ($item->isDot() || $item->getFilename() === 'definition.json') {
+                        continue;
+                    }
+                    if (!rename(
+                        $item->getPathname(),
+                        $destination . DIRECTORY_SEPARATOR . $item->getFilename()
+                    )) {
+                        throw new RuntimeException('Generated add-on contents could not be published.');
+                    }
+                }
+
+                // BlueCore treats definition.json as the discovery marker.
+                if (!rename($definition, $destination . DIRECTORY_SEPARATOR . 'definition.json')) {
+                    throw new RuntimeException('Generated add-on definition could not be published.');
+                }
+            } catch (Throwable $exception) {
+                $this->removeDirectory($destination);
+
+                throw $exception;
             }
 
             return true;

--- a/app/Business/Services/AddOnScaffoldService.php
+++ b/app/Business/Services/AddOnScaffoldService.php
@@ -8,6 +8,7 @@ use BlueFission\Arr;
 use BlueFission\Data\FileSystem;
 use BlueFission\Services\Service;
 use BlueFission\Str;
+use DirectoryIterator;
 use InvalidArgumentException;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -48,6 +49,14 @@ final class AddOnScaffoldService extends Service
             }
 
             $destination = $this->destination($target);
+            if ($this->isInstalledDestination($destination)
+                && FileSystem::fileBasename($destination) !== $name
+            ) {
+                return $this->failure(
+                    'destination_name_mismatch',
+                    'An installed add-on directory must match its lifecycle name.'
+                );
+            }
             if (FileSystem::fileExists($destination) || FileSystem::directoryExists($destination)) {
                 return $this->failure('destination_exists', 'Destination already exists.');
             }
@@ -81,14 +90,14 @@ final class AddOnScaffoldService extends Service
                     ];
                 }
 
-                if (!rename($staging, $destination)) {
-                    throw new RuntimeException('Generated add-on could not be published.');
+                if (!$this->publish($staging, $destination)) {
+                    return $this->failure('destination_exists', 'Destination already exists.');
                 }
 
                 return [
                     'created' => true,
                     'path' => $destination,
-                    'files' => array_keys($files),
+                    'files' => Arr::make($files)->keys()->val(),
                     'errors' => [],
                     'warnings' => $validation->get('warnings'),
                 ];
@@ -129,12 +138,19 @@ final class AddOnScaffoldService extends Service
             'namespace' => $namespace,
             'libraries' => [],
             'primary_file' => 'main.php',
+            'registration' => [
+                'class' => $namespace . '\\Registration\\AddOnRegistration',
+                'factory' => 'main.php',
+            ],
+            'themes' => [
+                'default' => [
+                    'directory' => 'resource/markup',
+                    'entrypoint' => 'default.vibe',
+                ],
+            ],
         ];
 
-        $registration = str_replace(
-            ['{{NAMESPACE}}'],
-            [$namespace],
-            <<<'PHP'
+        $registration = Str::make(<<<'PHP'
 <?php
 
 declare(strict_types=1);
@@ -155,11 +171,8 @@ final class AddOnRegistration
     }
 }
 PHP
-        );
-        $main = str_replace(
-            ['{{NAME}}', '{{NAMESPACE}}'],
-            [$name, $namespace],
-            <<<'PHP'
+        )->replace('{{NAMESPACE}}', $namespace)->val();
+        $main = Str::make(<<<'PHP'
 <?php
 
 declare(strict_types=1);
@@ -176,11 +189,14 @@ function {{NAME}}_uninstall(): void
 
 return static fn (): AddOnRegistration => new AddOnRegistration();
 PHP
-        );
+        )
+            ->replace('{{NAME}}', $name)
+            ->replace('{{NAMESPACE}}', $namespace)
+            ->val();
 
         return [
-            'composer.json' => json_encode($composer, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n",
-            'definition.json' => json_encode($definition, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n",
+            'composer.json' => $this->json($composer),
+            'definition.json' => $this->json($definition),
             'main.php' => $main . "\n",
             'README.md' => "# {$className}\n\n{$className} is an Opus add-on.\n",
             'logic/Registration/AddOnRegistration.php' => $registration . "\n",
@@ -191,7 +207,7 @@ PHP
             'mapping/menus.php' => $this->menus(),
             'resource/markup/default.vibe' => "<section>\n  <h1>{\$title}</h1>\n</section>\n",
             'phpunit.xml' => $this->phpunitConfiguration(),
-            'tests/bootstrap.php' => "<?php\n\ndeclare(strict_types=1);\n\nrequire dirname(__DIR__) . '/vendor/autoload.php';\n",
+            'tests/bootstrap.php' => $this->testBootstrap(),
         ];
     }
 
@@ -236,6 +252,29 @@ PHP;
     </testsuites>
 </phpunit>
 XML;
+    }
+
+    private function testBootstrap(): string
+    {
+        return <<<'PHP'
+<?php
+
+declare(strict_types=1);
+
+$autoloaders = [
+    dirname(__DIR__) . '/vendor/autoload.php',
+    dirname(__DIR__, 3) . '/vendor/autoload.php',
+];
+
+foreach ($autoloaders as $autoloader) {
+    if (is_file($autoloader)) {
+        require $autoloader;
+        return;
+    }
+}
+
+throw new RuntimeException('Composer autoloader could not be resolved.');
+PHP;
     }
 
     private function directories(): array
@@ -305,6 +344,42 @@ XML;
         }
     }
 
+    private function publish(string $staging, string $destination): bool
+    {
+        // Creating the destination is the atomic no-clobber claim. Contents are
+        // moved only after this process owns that directory.
+        set_error_handler(static fn (): bool => true);
+        try {
+            $reserved = mkdir($destination, 0777);
+        } finally {
+            restore_error_handler();
+        }
+
+        if (!$reserved) {
+            if (FileSystem::fileExists($destination) || FileSystem::directoryExists($destination)) {
+                return false;
+            }
+
+            throw new RuntimeException('Generated add-on destination could not be reserved.');
+        }
+
+        foreach (new DirectoryIterator($staging) as $item) {
+            if ($item->isDot()) {
+                continue;
+            }
+
+            $target = $destination . DIRECTORY_SEPARATOR . $item->getFilename();
+            if (FileSystem::fileExists($target) || FileSystem::directoryExists($target)) {
+                throw new RuntimeException('Generated add-on destination changed during publication.');
+            }
+            if (!rename($item->getPathname(), $target)) {
+                throw new RuntimeException('Generated add-on contents could not be published.');
+            }
+        }
+
+        return true;
+    }
+
     private function removeDirectory(string $directory): void
     {
         $iterator = new RecursiveIteratorIterator(
@@ -333,6 +408,20 @@ XML;
     private function normalize(string $path): string
     {
         return Str::make(Str::replace($path, '\\', '/'))->trim('/')->val();
+    }
+
+    private function isInstalledDestination(string $destination): bool
+    {
+        $addons = $this->normalize($this->workspace . DIRECTORY_SEPARATOR . 'addons');
+
+        return $this->normalize(dirname($destination)) === $addons;
+    }
+
+    private function json(array $value): string
+    {
+        return Str::make(Arr::make($value)->toJson())
+            ->append(PHP_EOL)
+            ->val();
     }
 
     private function isAbsolute(string $path): bool

--- a/app/Business/Services/AddOnScaffoldService.php
+++ b/app/Business/Services/AddOnScaffoldService.php
@@ -37,7 +37,7 @@ final class AddOnScaffoldService extends Service
     {
         try {
             $name = Str::make($name)->trim()->lower()->val();
-            if (!Str::make($name)->matches('/^[a-z][a-z0-9_]*$/')) {
+            if (!Str::make($name)->matches('/^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$/')) {
                 return $this->failure('name_invalid', 'Add-on name must be a lowercase lifecycle-safe key.');
             }
 

--- a/bin/opus-addon.php
+++ b/bin/opus-addon.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use App\Business\Services\AddOnContractValidator;
 use App\Business\Services\AddOnScaffoldService;
+use BlueFission\Arr;
+use BlueFission\Str;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
@@ -14,14 +16,14 @@ if ($command === 'generate') {
     $target = $argv[3] ?? '';
     $namespace = $argv[4] ?? null;
     $result = (new AddOnScaffoldService())->generate($name, $target, $namespace);
-    print json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+    print Str::make(Arr::make($result)->toJson())->append(PHP_EOL)->val();
     exit($result['created'] ? 0 : 1);
 }
 
 if ($command === 'validate') {
     $target = $argv[2] ?? '';
     $result = (new AddOnContractValidator())->validate($target);
-    print json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+    print Str::make(Arr::make($result)->toJson())->append(PHP_EOL)->val();
     exit($result['valid'] ? 0 : 1);
 }
 

--- a/bin/opus-addon.php
+++ b/bin/opus-addon.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business\Services\AddOnContractValidator;
+use App\Business\Services\AddOnScaffoldService;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$command = $argv[1] ?? '';
+
+if ($command === 'generate') {
+    $name = $argv[2] ?? '';
+    $target = $argv[3] ?? '';
+    $namespace = $argv[4] ?? null;
+    $result = (new AddOnScaffoldService())->generate($name, $target, $namespace);
+    print json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+    exit($result['created'] ? 0 : 1);
+}
+
+if ($command === 'validate') {
+    $target = $argv[2] ?? '';
+    $result = (new AddOnContractValidator())->validate($target);
+    print json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+    exit($result['valid'] ? 0 : 1);
+}
+
+fwrite(STDERR, "Usage:\n  php bin/opus-addon.php generate <name> <target> [namespace]\n  php bin/opus-addon.php validate <target>\n");
+exit(2);

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -401,12 +401,36 @@ declare(strict_types=1);
 use BlueFission\Services\Mapping;
 
 Mapping::add('/health', ['HealthController', 'index'], 'health', 'get')->gateway('auth');
+Mapping::add('/lazy', static function (): array {
+    return [];
+}, 'lazy', 'get');
 PHP
         );
 
         $result = (new AddOnContractValidator())->validate($this->workspace . '/mapped');
 
         $this->assertTrue($result['valid'], Arr::make($result['errors'])->toJson());
+    }
+
+    public function testExecutableMappingsRequireTheShortNameImport(): void
+    {
+        (new AddOnScaffoldService($this->workspace))->generate('missing_import', 'missing_import');
+        file_put_contents(
+            $this->workspace . '/missing_import/mapping/api.php',
+            <<<'PHP'
+<?php
+
+Mapping::add('/health', ['HealthController', 'index'], 'health', 'get');
+PHP
+        );
+
+        $result = (new AddOnContractValidator())->validate($this->workspace . '/missing_import');
+        $codes = Arr::make($result['errors'])
+            ->map(fn (array $error): string => (string) Arr::make($error)->get('code'))
+            ->val();
+
+        $this->assertFalse($result['valid']);
+        $this->assertContains('mapping_contract', $codes);
     }
 
     public function testItUsesDeclaredRegistrationAndDirectoryThemeEntrypoints(): void

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -594,6 +594,30 @@ PHP
         $this->assertTrue($result['valid'], Arr::make($result['errors'])->toJson());
     }
 
+    public function testRegistrationClassCannotRelyOnAnUnresolvedInheritedConstructor(): void
+    {
+        (new AddOnScaffoldService($this->workspace))->generate('inherited_constructor', 'inherited_constructor');
+        $registration = $this->workspace
+            . '/inherited_constructor/logic/Registration/AddOnRegistration.php';
+        file_put_contents(
+            $registration,
+            Str::make((string) FileSystem::fileContents($registration))
+                ->replace(
+                    'final class AddOnRegistration',
+                    'final class AddOnRegistration extends \\Vendor\\ParentRegistration'
+                )
+                ->val()
+        );
+
+        $result = (new AddOnContractValidator())->validate($this->workspace . '/inherited_constructor');
+        $codes = Arr::make($result['errors'])
+            ->map(fn (array $error): string => (string) Arr::make($error)->get('code'))
+            ->val();
+
+        $this->assertFalse($result['valid']);
+        $this->assertContains('registration_class', $codes);
+    }
+
     public function testRegistrationFactoryRejectsTopLevelExecution(): void
     {
         (new AddOnScaffoldService($this->workspace))->generate('factory_execution', 'factory_execution');

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Business\Services;
+
+use App\Business\Services\AddOnContractValidator;
+use App\Business\Services\AddOnScaffoldService;
+use BlueFission\Data\FileSystem;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+final class AddOnScaffoldServiceTest extends TestCase
+{
+    private string $workspace;
+
+    protected function setUp(): void
+    {
+        $this->workspace = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'opus-addon-' . bin2hex(random_bytes(6));
+        mkdir($this->workspace, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if (FileSystem::directoryExists($this->workspace)) {
+            $this->removeDirectory($this->workspace);
+        }
+    }
+
+    public function testItGeneratesAndValidatesTheCanonicalStructure(): void
+    {
+        $service = new AddOnScaffoldService($this->workspace);
+        $result = $service->generate('sample_tools', 'sample_tools');
+
+        $this->assertTrue($result['created'], json_encode($result['errors']));
+        $this->assertFileExists($this->workspace . '/sample_tools/resource/markup/default.vibe');
+        $this->assertFileExists($this->workspace . '/sample_tools/datasources/structure/.gitkeep');
+        $composer = json_decode((string) file_get_contents($this->workspace . '/sample_tools/composer.json'), true);
+        $this->assertSame('proprietary', $composer['license']);
+
+        $validation = (new AddOnContractValidator())->validate($this->workspace . '/sample_tools');
+        $this->assertTrue($validation['valid'], json_encode($validation['errors']));
+
+        $menus = require $this->workspace . '/sample_tools/mapping/menus.php';
+        $this->assertIsArray($menus);
+        $this->assertSame([], $menus['register']());
+
+        require $this->workspace . '/sample_tools/logic/Registration/AddOnRegistration.php';
+        $factory = require $this->workspace . '/sample_tools/main.php';
+        $registration = $factory();
+        $this->assertCount(5, $registration->contributions());
+    }
+
+    public function testItRejectsUnsafeNamesWithoutWritingOutput(): void
+    {
+        $result = (new AddOnScaffoldService($this->workspace))->generate('../unsafe', 'unsafe');
+
+        $this->assertFalse($result['created']);
+        $this->assertSame('name_invalid', $result['errors'][0]['code']);
+        $this->assertDirectoryDoesNotExist($this->workspace . '/unsafe');
+    }
+
+    public function testItProtectsExistingDestinations(): void
+    {
+        mkdir($this->workspace . '/existing');
+
+        $result = (new AddOnScaffoldService($this->workspace))->generate('existing', 'existing');
+
+        $this->assertFalse($result['created']);
+        $this->assertSame('destination_exists', $result['errors'][0]['code']);
+    }
+
+    public function testItReportsInvalidComposerAndTemplateContracts(): void
+    {
+        $service = new AddOnScaffoldService($this->workspace);
+        $service->generate('broken', 'broken');
+        file_put_contents($this->workspace . '/broken/composer.json', '{"type":"library"}');
+        file_put_contents($this->workspace . '/broken/resource/markup/legacy.html', '<h1>Legacy</h1>');
+        file_put_contents($this->workspace . '/broken/resource/markup/default.vibe', '{#if ready}');
+        file_put_contents($this->workspace . '/broken/mapping/api.php', "<?php\nreturn 'invalid';\n");
+
+        $result = (new AddOnContractValidator())->validate($this->workspace . '/broken');
+        $codes = array_column($result['errors'], 'code');
+
+        $this->assertFalse($result['valid']);
+        $this->assertContains('composer_type', $codes);
+        $this->assertContains('template_extension', $codes);
+        $this->assertContains('template_syntax', $codes);
+        $this->assertContains('mapping_contract', $codes);
+    }
+
+    public function testItRejectsDestinationsOutsideTheWorkspace(): void
+    {
+        $result = (new AddOnScaffoldService($this->workspace))->generate(
+            'outside',
+            dirname($this->workspace) . DIRECTORY_SEPARATOR . 'outside'
+        );
+
+        $this->assertFalse($result['created']);
+        $this->assertStringContainsString('inside', $result['errors'][0]['message']);
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($directory, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($iterator as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($directory);
+    }
+}

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -464,6 +464,28 @@ PHP
         $this->assertContains('registration_class', $codes);
     }
 
+    public function testRegistrationClassCannotBeConditionallyDeclaredWithAlternativeSyntax(): void
+    {
+        (new AddOnScaffoldService($this->workspace))->generate('conditional_registration', 'conditional_registration');
+        $registration = $this->workspace
+            . '/conditional_registration/logic/Registration/AddOnRegistration.php';
+        file_put_contents(
+            $registration,
+            Str::make((string) FileSystem::fileContents($registration))
+                ->replace('final class AddOnRegistration', "if (false):\nfinal class AddOnRegistration")
+                ->append("\nendif;\n")
+                ->val()
+        );
+
+        $result = (new AddOnContractValidator())->validate($this->workspace . '/conditional_registration');
+        $codes = Arr::make($result['errors'])
+            ->map(fn (array $error): string => (string) Arr::make($error)->get('code'))
+            ->val();
+
+        $this->assertFalse($result['valid']);
+        $this->assertContains('registration_class', $codes);
+    }
+
     public function testRegistrationFactoryRejectsTopLevelExecution(): void
     {
         (new AddOnScaffoldService($this->workspace))->generate('factory_execution', 'factory_execution');

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -257,6 +257,10 @@ PHP
             $this->workspace . '/indirect/mapping/default.php',
             "<?php\nreturn [true()];\n"
         );
+        file_put_contents(
+            $this->workspace . '/indirect/mapping/console.php',
+            "<?php\nreturn [stdClass::class()];\n"
+        );
 
         $result = (new AddOnContractValidator())->validate($this->workspace . '/indirect');
         $mappingErrors = Arr::make($result['errors'])->filter(
@@ -264,7 +268,7 @@ PHP
         );
 
         $this->assertFalse($result['valid']);
-        $this->assertCount(3, $mappingErrors->val());
+        $this->assertCount(4, $mappingErrors->val());
     }
 
     public function testItRejectsShellExpressionsInDeclarativeMappings(): void
@@ -388,6 +392,29 @@ PHP
         $this->assertContains('registration_factory', $codes);
     }
 
+    public function testRegistrationFactoryMustProduceTheConfiguredClass(): void
+    {
+        (new AddOnScaffoldService($this->workspace))->generate('factory_result', 'factory_result');
+        $main = $this->workspace . '/factory_result/main.php';
+        file_put_contents(
+            $main,
+            Str::make((string) FileSystem::fileContents($main))
+                ->replace(
+                    'return static fn (): AddOnRegistration => new AddOnRegistration();',
+                    'return static fn (): int => 1;'
+                )
+                ->val()
+        );
+
+        $result = (new AddOnContractValidator())->validate($this->workspace . '/factory_result');
+        $codes = Arr::make($result['errors'])
+            ->map(fn (array $error): string => (string) Arr::make($error)->get('code'))
+            ->val();
+
+        $this->assertFalse($result['valid']);
+        $this->assertContains('registration_factory', $codes);
+    }
+
     public function testItAcceptsSupportedExecutableMappings(): void
     {
         (new AddOnScaffoldService($this->workspace))->generate('mapped', 'mapped');
@@ -404,6 +431,13 @@ Mapping::add('/health', ['HealthController', 'index'], 'health', 'get')->gateway
 Mapping::add('/lazy', static function (): array {
     return [];
 }, 'lazy', 'get');
+Mapping::add('/nested', static function (): array {
+    $inner = static function (): array {
+        return [];
+    };
+
+    return $inner();
+}, 'nested', 'get');
 PHP
         );
 

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -675,6 +675,12 @@ Mapping::add('/nested-arrow', static fn (): array => helper(
     static fn (): array => [],
     service('items')
 ), 'nested-arrow', 'get');
+Mapping::add(
+    '/default-array',
+    static fn (array $value = ['x' => 1]): array => $value,
+    'default-array',
+    'get'
+);
 PHP
         );
 

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -285,6 +285,10 @@ PHP
             $this->workspace . '/indirect/mapping/console.php',
             "<?php\nreturn [stdClass::class()];\n"
         );
+        file_put_contents(
+            $this->workspace . '/indirect/mapping/menus.php',
+            "<?php\nreturn [(static function (): void {})[0]];\n"
+        );
 
         $result = (new AddOnContractValidator())->validate($this->workspace . '/indirect');
         $mappingErrors = Arr::make($result['errors'])->filter(
@@ -292,7 +296,7 @@ PHP
         );
 
         $this->assertFalse($result['valid']);
-        $this->assertCount(4, $mappingErrors->val());
+        $this->assertCount(5, $mappingErrors->val());
     }
 
     public function testItRejectsShellExpressionsInDeclarativeMappings(): void
@@ -396,15 +400,6 @@ PHP
         file_put_contents(
             $main,
             Str::make((string) FileSystem::fileContents($main))
-                ->replace(
-                    'use AddOns\\HookInterpolation\\Registration\\AddOnRegistration;',
-                    <<<'PHP'
-use function Vendor\Package\prepare;
-use const Vendor\Package\STATUS;
-
-use AddOns\HookInterpolation\Registration\AddOnRegistration;
-PHP
-                )
                 ->replace(
                     'return static fn (): AddOnRegistration => new AddOnRegistration();',
                     <<<'PHP'
@@ -584,24 +579,36 @@ PHP
     {
         (new AddOnScaffoldService($this->workspace))->generate('hook_interpolation', 'hook_interpolation');
         $main = $this->workspace . '/hook_interpolation/main.php';
-        file_put_contents(
-            $main,
-            Str::make((string) FileSystem::fileContents($main))
-                ->replace(
-                    "function hook_interpolation_install(): void\n{\n}",
-                    <<<'PHP'
+        $source = Str::make((string) FileSystem::fileContents($main))
+            ->replace(
+                'use AddOns\\HookInterpolation\\Registration\\AddOnRegistration;',
+                <<<'PHP'
+use function Vendor\Package\prepare;
+use const Vendor\Package\STATUS;
+
+use AddOns\HookInterpolation\Registration\AddOnRegistration;
+PHP
+            )
+            ->replace(
+                "function hook_interpolation_install(): void\n{\n}",
+                <<<'PHP'
 function hook_interpolation_install(): void
 {
     $name = 'hook_interpolation';
     $message = "Installing {$name}";
 }
 PHP
-                )
-                ->val()
+            )
+            ->val();
+        file_put_contents(
+            $main,
+            $source
         );
 
         $result = (new AddOnContractValidator())->validate($this->workspace . '/hook_interpolation');
 
+        $this->assertStringContainsString('use function Vendor\\Package\\prepare;', $source);
+        $this->assertStringContainsString('use const Vendor\\Package\\STATUS;', $source);
         $this->assertTrue($result['valid'], Arr::make($result['errors'])->toJson());
     }
 

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -524,6 +524,31 @@ PHP
         $this->assertContains('registration_factory', $codes);
     }
 
+    public function testRegistrationFactoryAcceptsInterpolationInsideLifecycleHooks(): void
+    {
+        (new AddOnScaffoldService($this->workspace))->generate('hook_interpolation', 'hook_interpolation');
+        $main = $this->workspace . '/hook_interpolation/main.php';
+        file_put_contents(
+            $main,
+            Str::make((string) FileSystem::fileContents($main))
+                ->replace(
+                    "function hook_interpolation_install(): void\n{\n}",
+                    <<<'PHP'
+function hook_interpolation_install(): void
+{
+    $name = 'hook_interpolation';
+    $message = "Installing {$name}";
+}
+PHP
+                )
+                ->val()
+        );
+
+        $result = (new AddOnContractValidator())->validate($this->workspace . '/hook_interpolation');
+
+        $this->assertTrue($result['valid'], Arr::make($result['errors'])->toJson());
+    }
+
     public function testItAcceptsSupportedExecutableMappings(): void
     {
         (new AddOnScaffoldService($this->workspace))->generate('mapped', 'mapped');

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -289,6 +289,10 @@ PHP
             $this->workspace . '/indirect/mapping/menus.php',
             "<?php\nreturn [(static function (): void {})[0]];\n"
         );
+        file_put_contents(
+            $this->workspace . '/indirect/mapping/arrow-key.php',
+            "<?php\nreturn [static fn (): int => 1 => file_put_contents('side-effect', 'run')];\n"
+        );
 
         $result = (new AddOnContractValidator())->validate($this->workspace . '/indirect');
         $mappingErrors = Arr::make($result['errors'])->filter(
@@ -296,7 +300,7 @@ PHP
         );
 
         $this->assertFalse($result['valid']);
-        $this->assertCount(5, $mappingErrors->val());
+        $this->assertCount(6, $mappingErrors->val());
     }
 
     public function testItRejectsShellExpressionsInDeclarativeMappings(): void
@@ -482,6 +486,38 @@ PHP
         );
 
         $result = (new AddOnContractValidator())->validate($this->workspace . '/conditional_registration');
+        $codes = Arr::make($result['errors'])
+            ->map(fn (array $error): string => (string) Arr::make($error)->get('code'))
+            ->val();
+
+        $this->assertFalse($result['valid']);
+        $this->assertContains('registration_class', $codes);
+    }
+
+    public function testRegistrationClassMustBelongToItsDeclaredNamespace(): void
+    {
+        (new AddOnScaffoldService($this->workspace))->generate('split_namespace', 'split_namespace');
+        $registration = $this->workspace
+            . '/split_namespace/logic/Registration/AddOnRegistration.php';
+        file_put_contents(
+            $registration,
+            <<<'PHP'
+<?php
+
+declare(strict_types=1);
+
+namespace AddOns\SplitNamespace\Registration {
+}
+
+namespace Other {
+    final class AddOnRegistration
+    {
+    }
+}
+PHP
+        );
+
+        $result = (new AddOnContractValidator())->validate($this->workspace . '/split_namespace');
         $codes = Arr::make($result['errors'])
             ->map(fn (array $error): string => (string) Arr::make($error)->get('code'))
             ->val();

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -75,6 +75,19 @@ final class AddOnScaffoldServiceTest extends TestCase
         $this->assertDirectoryDoesNotExist($this->workspace . '/unsafe');
     }
 
+    public function testItRejectsNamesThatCannotProduceValidComposerSlugs(): void
+    {
+        $service = new AddOnScaffoldService($this->workspace);
+
+        foreach (['sample_', 'sample__tools'] as $name) {
+            $result = $service->generate($name, $name);
+
+            $this->assertFalse($result['created']);
+            $this->assertSame('name_invalid', $result['errors'][0]['code']);
+            $this->assertDirectoryDoesNotExist($this->workspace . '/' . $name);
+        }
+    }
+
     public function testItProtectsExistingDestinations(): void
     {
         mkdir($this->workspace . '/existing');
@@ -97,6 +110,21 @@ final class AddOnScaffoldServiceTest extends TestCase
         $this->assertFalse($result['created']);
         $this->assertSame('destination_name_mismatch', $result['errors'][0]['code']);
         $this->assertDirectoryDoesNotExist($this->workspace . '/addons/tools');
+    }
+
+    public function testValidatorRejectsARenamedInstalledDirectory(): void
+    {
+        (new AddOnScaffoldService($this->workspace))->generate('sample_tools', 'sample_tools');
+        mkdir($this->workspace . '/addons');
+        rename($this->workspace . '/sample_tools', $this->workspace . '/addons/tools');
+
+        $result = (new AddOnContractValidator())->validate($this->workspace . '/addons/tools');
+        $codes = Arr::make($result['errors'])
+            ->map(fn (array $error): string => (string) Arr::make($error)->get('code'))
+            ->val();
+
+        $this->assertFalse($result['valid']);
+        $this->assertContains('installed_identity', $codes);
     }
 
     public function testPublicationDoesNotReplaceARacedDestination(): void
@@ -166,6 +194,17 @@ final class AddOnScaffoldServiceTest extends TestCase
             $this->workspace . '/broken/mapping/default.php',
             "<?php\nreturn [\\file_put_contents('side-effect', 'run')];\n"
         );
+        file_put_contents(
+            $this->workspace . '/broken/mapping/menus.php',
+            <<<'PHP'
+<?php
+
+return [(static function (): array {
+    file_put_contents('side-effect', 'run');
+    return [];
+})()];
+PHP
+        );
 
         $result = (new AddOnContractValidator())->validate($this->workspace . '/broken');
         $codes = Arr::make($result['errors'])
@@ -177,7 +216,7 @@ final class AddOnScaffoldServiceTest extends TestCase
         $this->assertContains('template_extension', $codes);
         $this->assertContains('template_syntax', $codes);
         $this->assertContains('mapping_contract', $codes);
-        $this->assertGreaterThanOrEqual(4, Arr::make($codes)->filter(
+        $this->assertGreaterThanOrEqual(5, Arr::make($codes)->filter(
             fn (string $code): bool => $code === 'mapping_contract'
         )->count());
     }

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -6,7 +6,10 @@ namespace Tests\Unit\Business\Services;
 
 use App\Business\Services\AddOnContractValidator;
 use App\Business\Services\AddOnScaffoldService;
+use BlueFission\Arr;
 use BlueFission\Data\FileSystem;
+use BlueFission\Net\HTTP;
+use BlueFission\Str;
 use PHPUnit\Framework\TestCase;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -33,14 +36,25 @@ final class AddOnScaffoldServiceTest extends TestCase
         $service = new AddOnScaffoldService($this->workspace);
         $result = $service->generate('sample_tools', 'sample_tools');
 
-        $this->assertTrue($result['created'], json_encode($result['errors']));
+        $this->assertTrue($result['created'], Arr::make($result['errors'])->toJson());
         $this->assertFileExists($this->workspace . '/sample_tools/resource/markup/default.vibe');
         $this->assertFileExists($this->workspace . '/sample_tools/datasources/structure/.gitkeep');
-        $composer = json_decode((string) file_get_contents($this->workspace . '/sample_tools/composer.json'), true);
-        $this->assertSame('proprietary', $composer['license']);
+        $composer = Arr::make($this->readJson($this->workspace . '/sample_tools/composer.json'));
+        $definition = Arr::make($this->readJson($this->workspace . '/sample_tools/definition.json'));
+        $this->assertSame('proprietary', $composer->get('license'));
+        $this->assertSame('bluefission/opus-addon-sample-tools', $composer->get('name'));
+        $this->assertSame('sample_tools', Arr::make($composer->get('extra'))->get('installer-name'));
+        $this->assertSame(
+            'AddOns\\SampleTools\\Registration\\AddOnRegistration',
+            Arr::make($definition->get('registration'))->get('class')
+        );
+        $this->assertSame(
+            'default.vibe',
+            Arr::make(Arr::make($definition->get('themes'))->get('default'))->get('entrypoint')
+        );
 
         $validation = (new AddOnContractValidator())->validate($this->workspace . '/sample_tools');
-        $this->assertTrue($validation['valid'], json_encode($validation['errors']));
+        $this->assertTrue($validation['valid'], Arr::make($validation['errors'])->toJson());
 
         $menus = require $this->workspace . '/sample_tools/mapping/menus.php';
         $this->assertIsArray($menus);
@@ -71,6 +85,37 @@ final class AddOnScaffoldServiceTest extends TestCase
         $this->assertSame('destination_exists', $result['errors'][0]['code']);
     }
 
+    public function testInstalledDirectoryMustMatchTheLifecycleName(): void
+    {
+        mkdir($this->workspace . '/addons');
+
+        $result = (new AddOnScaffoldService($this->workspace))->generate(
+            'sample_tools',
+            'addons/tools'
+        );
+
+        $this->assertFalse($result['created']);
+        $this->assertSame('destination_name_mismatch', $result['errors'][0]['code']);
+        $this->assertDirectoryDoesNotExist($this->workspace . '/addons/tools');
+    }
+
+    public function testPublicationDoesNotReplaceARacedDestination(): void
+    {
+        $staging = $this->workspace . '/staging';
+        $destination = $this->workspace . '/raced';
+        mkdir($staging);
+        file_put_contents($staging . '/payload.txt', 'generated');
+        mkdir($destination);
+        file_put_contents($destination . '/owner.txt', 'existing');
+
+        $service = new AddOnScaffoldService($this->workspace);
+        $publish = new \ReflectionMethod($service, 'publish');
+
+        $this->assertFalse($publish->invoke($service, $staging, $destination));
+        $this->assertSame('existing', FileSystem::fileContents($destination . '/owner.txt'));
+        $this->assertFileDoesNotExist($destination . '/payload.txt');
+    }
+
     public function testItReportsInvalidComposerAndTemplateContracts(): void
     {
         $service = new AddOnScaffoldService($this->workspace);
@@ -79,15 +124,117 @@ final class AddOnScaffoldServiceTest extends TestCase
         file_put_contents($this->workspace . '/broken/resource/markup/legacy.html', '<h1>Legacy</h1>');
         file_put_contents($this->workspace . '/broken/resource/markup/default.vibe', '{#if ready}');
         file_put_contents($this->workspace . '/broken/mapping/api.php', "<?php\nreturn 'invalid';\n");
+        file_put_contents(
+            $this->workspace . '/broken/mapping/app.php',
+            "<?php\nfile_put_contents('side-effect', 'run');\nreturn [];\n"
+        );
 
         $result = (new AddOnContractValidator())->validate($this->workspace . '/broken');
-        $codes = array_column($result['errors'], 'code');
+        $codes = Arr::make($result['errors'])
+            ->map(fn (array $error): string => (string) Arr::make($error)->get('code'))
+            ->val();
 
         $this->assertFalse($result['valid']);
         $this->assertContains('composer_type', $codes);
         $this->assertContains('template_extension', $codes);
         $this->assertContains('template_syntax', $codes);
         $this->assertContains('mapping_contract', $codes);
+        $this->assertGreaterThanOrEqual(2, Arr::make($codes)->filter(
+            fn (string $code): bool => $code === 'mapping_contract'
+        )->count());
+    }
+
+    public function testItAcceptsSupportedExecutableMappings(): void
+    {
+        (new AddOnScaffoldService($this->workspace))->generate('mapped', 'mapped');
+        file_put_contents(
+            $this->workspace . '/mapped/mapping/api.php',
+            <<<'PHP'
+<?php
+
+declare(strict_types=1);
+
+use BlueFission\Services\Mapping;
+
+Mapping::add('/health', ['HealthController', 'index'], 'health', 'get')->gateway('auth');
+PHP
+        );
+
+        $result = (new AddOnContractValidator())->validate($this->workspace . '/mapped');
+
+        $this->assertTrue($result['valid'], Arr::make($result['errors'])->toJson());
+    }
+
+    public function testItUsesDeclaredRegistrationAndDirectoryThemeEntrypoints(): void
+    {
+        (new AddOnScaffoldService($this->workspace))->generate('declared', 'declared');
+        $root = $this->workspace . '/declared';
+        mkdir($root . '/logic/Bootstrap');
+        rename(
+            $root . '/logic/Registration/AddOnRegistration.php',
+            $root . '/logic/Bootstrap/PackageRegistration.php'
+        );
+        file_put_contents(
+            $root . '/logic/Bootstrap/PackageRegistration.php',
+            Str::make((string) FileSystem::fileContents($root . '/logic/Bootstrap/PackageRegistration.php'))
+                ->replace('namespace AddOns\\Declared\\Registration;', 'namespace AddOns\\Declared\\Bootstrap;')
+                ->replace('class AddOnRegistration', 'class PackageRegistration')
+                ->val()
+        );
+        file_put_contents(
+            $root . '/main.php',
+            Str::make((string) FileSystem::fileContents($root . '/main.php'))
+                ->replace(
+                    'AddOns\\Declared\\Registration\\AddOnRegistration',
+                    'AddOns\\Declared\\Bootstrap\\PackageRegistration'
+                )
+                ->replace('AddOnRegistration', 'PackageRegistration')
+                ->val()
+        );
+        mkdir($root . '/resource/markup/default');
+        rename(
+            $root . '/resource/markup/default.vibe',
+            $root . '/resource/markup/default/index.vibe'
+        );
+
+        $definition = Arr::make($this->readJson($root . '/definition.json'));
+        $definition->set('registration', [
+            'class' => 'AddOns\\Declared\\Bootstrap\\PackageRegistration',
+            'factory' => 'main.php',
+        ]);
+        $definition->set('themes', [
+            'default' => [
+                'directory' => 'resource/markup/default',
+                'entrypoint' => 'index.vibe',
+            ],
+        ]);
+        file_put_contents($root . '/definition.json', Str::make($definition->toJson())->append(PHP_EOL)->val());
+
+        $result = (new AddOnContractValidator())->validate($root);
+
+        $this->assertTrue($result['valid'], Arr::make($result['errors'])->toJson());
+    }
+
+    public function testGeneratedBootstrapSupportsStandaloneAndInstalledPackages(): void
+    {
+        (new AddOnScaffoldService($this->workspace))->generate('standalone', 'standalone');
+        mkdir($this->workspace . '/standalone/vendor');
+        file_put_contents(
+            $this->workspace . '/standalone/vendor/autoload.php',
+            "<?php\n\$GLOBALS['opus_standalone_autoload'] = true;\n"
+        );
+        require $this->workspace . '/standalone/tests/bootstrap.php';
+        $this->assertTrue((bool) ($GLOBALS['opus_standalone_autoload'] ?? false));
+
+        mkdir($this->workspace . '/addons');
+        mkdir($this->workspace . '/vendor');
+        file_put_contents(
+            $this->workspace . '/vendor/autoload.php',
+            "<?php\n\$GLOBALS['opus_root_autoload'] = true;\n"
+        );
+        (new AddOnScaffoldService($this->workspace))->generate('installed', 'addons/installed');
+        require $this->workspace . '/addons/installed/tests/bootstrap.php';
+        $this->assertTrue((bool) ($GLOBALS['opus_root_autoload'] ?? false));
     }
 
     public function testItRejectsDestinationsOutsideTheWorkspace(): void
@@ -99,6 +246,11 @@ final class AddOnScaffoldServiceTest extends TestCase
 
         $this->assertFalse($result['created']);
         $this->assertStringContainsString('inside', $result['errors'][0]['message']);
+    }
+
+    private function readJson(string $path): array
+    {
+        return HTTP::jsonDecode((string) FileSystem::fileContents($path), true, []);
     }
 
     private function removeDirectory(string $directory): void

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -162,6 +162,10 @@ final class AddOnScaffoldServiceTest extends TestCase
             $this->workspace . '/broken/mapping/console.php',
             "<?php\nreturn [file_put_contents('side-effect', 'run')];\n"
         );
+        file_put_contents(
+            $this->workspace . '/broken/mapping/default.php',
+            "<?php\nreturn [\\file_put_contents('side-effect', 'run')];\n"
+        );
 
         $result = (new AddOnContractValidator())->validate($this->workspace . '/broken');
         $codes = Arr::make($result['errors'])
@@ -173,9 +177,30 @@ final class AddOnScaffoldServiceTest extends TestCase
         $this->assertContains('template_extension', $codes);
         $this->assertContains('template_syntax', $codes);
         $this->assertContains('mapping_contract', $codes);
-        $this->assertGreaterThanOrEqual(3, Arr::make($codes)->filter(
+        $this->assertGreaterThanOrEqual(4, Arr::make($codes)->filter(
             fn (string $code): bool => $code === 'mapping_contract'
         )->count());
+    }
+
+    public function testItAcceptsLazyArrowClosuresInDeclarativeMappings(): void
+    {
+        (new AddOnScaffoldService($this->workspace))->generate('lazy', 'lazy');
+        file_put_contents(
+            $this->workspace . '/lazy/mapping/menus.php',
+            <<<'PHP'
+<?php
+
+declare(strict_types=1);
+
+return [
+    'register' => static fn (): array => service('navigation')->all(),
+];
+PHP
+        );
+
+        $result = (new AddOnContractValidator())->validate($this->workspace . '/lazy');
+
+        $this->assertTrue($result['valid'], Arr::make($result['errors'])->toJson());
     }
 
     public function testItAcceptsSupportedExecutableMappings(): void

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -397,6 +397,15 @@ PHP
             $main,
             Str::make((string) FileSystem::fileContents($main))
                 ->replace(
+                    'use AddOns\\HookInterpolation\\Registration\\AddOnRegistration;',
+                    <<<'PHP'
+use function Vendor\Package\prepare;
+use const Vendor\Package\STATUS;
+
+use AddOns\HookInterpolation\Registration\AddOnRegistration;
+PHP
+                )
+                ->replace(
                     'return static fn (): AddOnRegistration => new AddOnRegistration();',
                     <<<'PHP'
 return static function (): AddOnRegistration {

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -526,6 +526,27 @@ PHP
         $this->assertContains('registration_class', $codes);
     }
 
+    public function testRegistrationClassMustBeConcrete(): void
+    {
+        (new AddOnScaffoldService($this->workspace))->generate('abstract_registration', 'abstract_registration');
+        $registration = $this->workspace
+            . '/abstract_registration/logic/Registration/AddOnRegistration.php';
+        file_put_contents(
+            $registration,
+            Str::make((string) FileSystem::fileContents($registration))
+                ->replace('final class AddOnRegistration', 'abstract class AddOnRegistration')
+                ->val()
+        );
+
+        $result = (new AddOnContractValidator())->validate($this->workspace . '/abstract_registration');
+        $codes = Arr::make($result['errors'])
+            ->map(fn (array $error): string => (string) Arr::make($error)->get('code'))
+            ->val();
+
+        $this->assertFalse($result['valid']);
+        $this->assertContains('registration_class', $codes);
+    }
+
     public function testRegistrationFactoryRejectsTopLevelExecution(): void
     {
         (new AddOnScaffoldService($this->workspace))->generate('factory_execution', 'factory_execution');
@@ -679,6 +700,12 @@ Mapping::add(
     '/default-array',
     static fn (array $value = ['x' => 1]): array => $value,
     'default-array',
+    'get'
+);
+Mapping::add(
+    '/keyed-yield',
+    static fn (): \Generator => yield 1 => service('item'),
+    'keyed-yield',
     'get'
 );
 PHP

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -284,6 +284,43 @@ PHP
         $this->assertCount(2, $mappingErrors->val());
     }
 
+    public function testItRejectsUnsafeEagerOperators(): void
+    {
+        (new AddOnScaffoldService($this->workspace))->generate('operator', 'operator');
+        file_put_contents(
+            $this->workspace . '/operator/mapping/api.php',
+            "<?php\nreturn [1 / 0];\n"
+        );
+
+        $result = (new AddOnContractValidator())->validate($this->workspace . '/operator');
+        $codes = Arr::make($result['errors'])
+            ->map(fn (array $error): string => (string) Arr::make($error)->get('code'))
+            ->val();
+
+        $this->assertFalse($result['valid']);
+        $this->assertContains('mapping_contract', $codes);
+    }
+
+    public function testItValidatesEveryDeclaredLibraryName(): void
+    {
+        (new AddOnScaffoldService($this->workspace))->generate('libraries', 'libraries');
+        $definitionPath = $this->workspace . '/libraries/definition.json';
+        $definition = Arr::make($this->readJson($definitionPath));
+        $definition->set('libraries', ['bluefission/develation', 'not-a-package']);
+        file_put_contents(
+            $definitionPath,
+            Str::make($definition->toJson())->append(PHP_EOL)->val()
+        );
+
+        $result = (new AddOnContractValidator())->validate($this->workspace . '/libraries');
+        $codes = Arr::make($result['errors'])
+            ->map(fn (array $error): string => (string) Arr::make($error)->get('code'))
+            ->val();
+
+        $this->assertFalse($result['valid']);
+        $this->assertContains('libraries_manifest', $codes);
+    }
+
     public function testItAcceptsSupportedExecutableMappings(): void
     {
         (new AddOnScaffoldService($this->workspace))->generate('mapped', 'mapped');

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -116,6 +116,36 @@ final class AddOnScaffoldServiceTest extends TestCase
         $this->assertFileDoesNotExist($destination . '/payload.txt');
     }
 
+    public function testPublicationLockKeepsTheStagedTreePrivate(): void
+    {
+        $staging = $this->workspace . '/staging';
+        $destination = $this->workspace . '/published';
+        mkdir($staging);
+        file_put_contents($staging . '/definition.json', '{}');
+        file_put_contents($staging . '/main.php', '<?php return [];');
+
+        $service = new AddOnScaffoldService($this->workspace);
+        $lockPath = (new \ReflectionMethod($service, 'publicationLockPath'))
+            ->invoke($service, $destination);
+        $lock = fopen($lockPath, 'c');
+        $this->assertIsResource($lock);
+        $this->assertTrue(flock($lock, LOCK_EX | LOCK_NB));
+
+        try {
+            $published = (new \ReflectionMethod($service, 'publish'))
+                ->invoke($service, $staging, $destination);
+
+            $this->assertFalse($published);
+            $this->assertDirectoryDoesNotExist($destination);
+            $this->assertFileExists($staging . '/definition.json');
+            $this->assertFileExists($staging . '/main.php');
+        } finally {
+            flock($lock, LOCK_UN);
+            fclose($lock);
+            unlink($lockPath);
+        }
+    }
+
     public function testItReportsInvalidComposerAndTemplateContracts(): void
     {
         $service = new AddOnScaffoldService($this->workspace);

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -242,6 +242,30 @@ PHP
         $this->assertTrue($result['valid'], Arr::make($result['errors'])->toJson());
     }
 
+    public function testNestedArrowClosuresCannotHideAnEagerSiblingExpression(): void
+    {
+        (new AddOnScaffoldService($this->workspace))->generate('nested_arrow', 'nested_arrow');
+        file_put_contents(
+            $this->workspace . '/nested_arrow/mapping/api.php',
+            <<<'PHP'
+<?php
+
+return [
+    static fn (): callable => static fn (): int => 1,
+    file_put_contents('side-effect', 'run'),
+];
+PHP
+        );
+
+        $result = (new AddOnContractValidator())->validate($this->workspace . '/nested_arrow');
+        $codes = Arr::make($result['errors'])
+            ->map(fn (array $error): string => (string) Arr::make($error)->get('code'))
+            ->val();
+
+        $this->assertFalse($result['valid']);
+        $this->assertContains('mapping_contract', $codes);
+    }
+
     public function testItRejectsIndirectEagerCallableExpressions(): void
     {
         (new AddOnScaffoldService($this->workspace))->generate('indirect', 'indirect');
@@ -458,6 +482,40 @@ PHP
         );
 
         $result = (new AddOnContractValidator())->validate($this->workspace . '/factory_alias');
+        $codes = Arr::make($result['errors'])
+            ->map(fn (array $error): string => (string) Arr::make($error)->get('code'))
+            ->val();
+
+        $this->assertFalse($result['valid']);
+        $this->assertContains('registration_factory', $codes);
+    }
+
+    public function testRegistrationFactoryIgnoresTraitUseStatementsWhenResolvingImports(): void
+    {
+        (new AddOnScaffoldService($this->workspace))->generate('trait_import', 'trait_import');
+        $main = $this->workspace . '/trait_import/main.php';
+        file_put_contents(
+            $main,
+            Str::make((string) FileSystem::fileContents($main))
+                ->replace('use AddOns\\TraitImport\\Registration\\AddOnRegistration;', '')
+                ->replace(
+                    'function trait_import_install(): void',
+                    <<<'PHP'
+function trait_import_decoy(): void
+{
+    class Decoy
+    {
+        use AddOns\TraitImport\Registration\AddOnRegistration;
+    }
+}
+
+function trait_import_install(): void
+PHP
+                )
+                ->val()
+        );
+
+        $result = (new AddOnContractValidator())->validate($this->workspace . '/trait_import');
         $codes = Arr::make($result['errors'])
             ->map(fn (array $error): string => (string) Arr::make($error)->get('code'))
             ->val();

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -439,6 +439,31 @@ PHP
         $this->assertContains('registration_factory', $codes);
     }
 
+    public function testRegistrationClassMustBeDeclaredAtNamespaceScope(): void
+    {
+        (new AddOnScaffoldService($this->workspace))->generate('nested_registration', 'nested_registration');
+        $registration = $this->workspace
+            . '/nested_registration/logic/Registration/AddOnRegistration.php';
+        file_put_contents(
+            $registration,
+            Str::make((string) FileSystem::fileContents($registration))
+                ->replace(
+                    'final class AddOnRegistration',
+                    "function declare_registration(): void\n{\nfinal class AddOnRegistration"
+                )
+                ->append("\n}\n")
+                ->val()
+        );
+
+        $result = (new AddOnContractValidator())->validate($this->workspace . '/nested_registration');
+        $codes = Arr::make($result['errors'])
+            ->map(fn (array $error): string => (string) Arr::make($error)->get('code'))
+            ->val();
+
+        $this->assertFalse($result['valid']);
+        $this->assertContains('registration_class', $codes);
+    }
+
     public function testRegistrationFactoryRejectsTopLevelExecution(): void
     {
         (new AddOnScaffoldService($this->workspace))->generate('factory_execution', 'factory_execution');

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -253,6 +253,10 @@ PHP
             $this->workspace . '/indirect/mapping/app.php',
             "<?php\nreturn [(['Example', 'run'])()];\n"
         );
+        file_put_contents(
+            $this->workspace . '/indirect/mapping/default.php',
+            "<?php\nreturn [true()];\n"
+        );
 
         $result = (new AddOnContractValidator())->validate($this->workspace . '/indirect');
         $mappingErrors = Arr::make($result['errors'])->filter(
@@ -260,7 +264,7 @@ PHP
         );
 
         $this->assertFalse($result['valid']);
-        $this->assertCount(2, $mappingErrors->val());
+        $this->assertCount(3, $mappingErrors->val());
     }
 
     public function testItRejectsShellExpressionsInDeclarativeMappings(): void
@@ -319,6 +323,69 @@ PHP
 
         $this->assertFalse($result['valid']);
         $this->assertContains('libraries_manifest', $codes);
+    }
+
+    public function testItAcceptsClassReferencesAsSafeDeclarativeValues(): void
+    {
+        (new AddOnScaffoldService($this->workspace))->generate('class_ref', 'class_ref');
+        file_put_contents(
+            $this->workspace . '/class_ref/mapping/api.php',
+            "<?php\nreturn ['handler' => HealthController::class];\n"
+        );
+
+        $result = (new AddOnContractValidator())->validate($this->workspace . '/class_ref');
+
+        $this->assertTrue($result['valid'], Arr::make($result['errors'])->toJson());
+    }
+
+    public function testItRejectsUnsafeExecutableMappingArguments(): void
+    {
+        (new AddOnScaffoldService($this->workspace))->generate('executable', 'executable');
+        file_put_contents(
+            $this->workspace . '/executable/mapping/api.php',
+            <<<'PHP'
+<?php
+
+use BlueFission\Services\Mapping;
+
+Mapping::add('/x', ['Controller', 'index'], 1 / 0, 'get');
+PHP
+        );
+
+        $result = (new AddOnContractValidator())->validate($this->workspace . '/executable');
+        $codes = Arr::make($result['errors'])
+            ->map(fn (array $error): string => (string) Arr::make($error)->get('code'))
+            ->val();
+
+        $this->assertFalse($result['valid']);
+        $this->assertContains('mapping_contract', $codes);
+    }
+
+    public function testRegistrationFactoryMustBeTheCompleteReturnExpression(): void
+    {
+        (new AddOnScaffoldService($this->workspace))->generate('factory', 'factory');
+        $main = $this->workspace . '/factory/main.php';
+        file_put_contents(
+            $main,
+            Str::make((string) FileSystem::fileContents($main))
+                ->replace(
+                    'return static fn (): AddOnRegistration => new AddOnRegistration();',
+                    <<<'PHP'
+return static function (): AddOnRegistration {
+    return new AddOnRegistration();
+} ? 1 : 0;
+PHP
+                )
+                ->val()
+        );
+
+        $result = (new AddOnContractValidator())->validate($this->workspace . '/factory');
+        $codes = Arr::make($result['errors'])
+            ->map(fn (array $error): string => (string) Arr::make($error)->get('code'))
+            ->val();
+
+        $this->assertFalse($result['valid']);
+        $this->assertContains('registration_factory', $codes);
     }
 
     public function testItAcceptsSupportedExecutableMappings(): void

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -242,6 +242,27 @@ PHP
         $this->assertTrue($result['valid'], Arr::make($result['errors'])->toJson());
     }
 
+    public function testItRejectsIndirectEagerCallableExpressions(): void
+    {
+        (new AddOnScaffoldService($this->workspace))->generate('indirect', 'indirect');
+        file_put_contents(
+            $this->workspace . '/indirect/mapping/api.php',
+            "<?php\nreturn [(('file_put_contents'))('side-effect', 'run')];\n"
+        );
+        file_put_contents(
+            $this->workspace . '/indirect/mapping/app.php',
+            "<?php\nreturn [(['Example', 'run'])()];\n"
+        );
+
+        $result = (new AddOnContractValidator())->validate($this->workspace . '/indirect');
+        $mappingErrors = Arr::make($result['errors'])->filter(
+            fn (array $error): bool => Arr::make($error)->get('code') === 'mapping_contract'
+        );
+
+        $this->assertFalse($result['valid']);
+        $this->assertCount(2, $mappingErrors->val());
+    }
+
     public function testItAcceptsSupportedExecutableMappings(): void
     {
         (new AddOnScaffoldService($this->workspace))->generate('mapped', 'mapped');

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -270,14 +270,18 @@ PHP
             $this->workspace . '/shell/mapping/api.php',
             "<?php\nreturn [`echo unsafe`];\n"
         );
+        file_put_contents(
+            $this->workspace . '/shell/mapping/app.php',
+            "<?php\nreturn [print 'unsafe'];\n"
+        );
 
         $result = (new AddOnContractValidator())->validate($this->workspace . '/shell');
-        $codes = Arr::make($result['errors'])
-            ->map(fn (array $error): string => (string) Arr::make($error)->get('code'))
-            ->val();
+        $mappingErrors = Arr::make($result['errors'])->filter(
+            fn (array $error): bool => Arr::make($error)->get('code') === 'mapping_contract'
+        );
 
         $this->assertFalse($result['valid']);
-        $this->assertContains('mapping_contract', $codes);
+        $this->assertCount(2, $mappingErrors->val());
     }
 
     public function testItAcceptsSupportedExecutableMappings(): void

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -415,6 +415,34 @@ PHP
         $this->assertContains('registration_factory', $codes);
     }
 
+    public function testRegistrationFactoryRejectsTopLevelExecution(): void
+    {
+        (new AddOnScaffoldService($this->workspace))->generate('factory_execution', 'factory_execution');
+        $root = $this->workspace . '/factory_execution';
+        $main = $root . '/main.php';
+        $marker = $root . '/executed.txt';
+        $eagerWrite = 'file_put_contents(' . var_export($marker, true) . ", 'run');";
+        file_put_contents(
+            $main,
+            Str::make((string) FileSystem::fileContents($main))
+                ->replace(
+                    'return static fn (): AddOnRegistration => new AddOnRegistration();',
+                    $eagerWrite . "\n"
+                        . 'return static fn (): AddOnRegistration => new AddOnRegistration();'
+                )
+                ->val()
+        );
+
+        $result = (new AddOnContractValidator())->validate($root);
+        $codes = Arr::make($result['errors'])
+            ->map(fn (array $error): string => (string) Arr::make($error)->get('code'))
+            ->val();
+
+        $this->assertFalse($result['valid']);
+        $this->assertContains('registration_factory', $codes);
+        $this->assertFalse(FileSystem::fileExists($marker));
+    }
+
     public function testRegistrationFactoryHonorsImportedAliases(): void
     {
         (new AddOnScaffoldService($this->workspace))->generate('factory_alias', 'factory_alias');

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -128,6 +128,10 @@ final class AddOnScaffoldServiceTest extends TestCase
             $this->workspace . '/broken/mapping/app.php',
             "<?php\nfile_put_contents('side-effect', 'run');\nreturn [];\n"
         );
+        file_put_contents(
+            $this->workspace . '/broken/mapping/console.php',
+            "<?php\nreturn [file_put_contents('side-effect', 'run')];\n"
+        );
 
         $result = (new AddOnContractValidator())->validate($this->workspace . '/broken');
         $codes = Arr::make($result['errors'])
@@ -139,7 +143,7 @@ final class AddOnScaffoldServiceTest extends TestCase
         $this->assertContains('template_extension', $codes);
         $this->assertContains('template_syntax', $codes);
         $this->assertContains('mapping_contract', $codes);
-        $this->assertGreaterThanOrEqual(2, Arr::make($codes)->filter(
+        $this->assertGreaterThanOrEqual(3, Arr::make($codes)->filter(
             fn (string $code): bool => $code === 'mapping_contract'
         )->count());
     }

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -534,7 +534,7 @@ PHP
         file_put_contents(
             $registration,
             Str::make((string) FileSystem::fileContents($registration))
-                ->replace('final class AddOnRegistration', 'abstract class AddOnRegistration')
+                ->replace('final class AddOnRegistration', 'abstract readonly class AddOnRegistration')
                 ->val()
         );
 
@@ -545,6 +545,53 @@ PHP
 
         $this->assertFalse($result['valid']);
         $this->assertContains('registration_class', $codes);
+    }
+
+    public function testRegistrationClassMustSupportPublicDefaultConstruction(): void
+    {
+        $invalidConstructors = Arr::make([
+            'private_constructor' => 'private function __construct() {}',
+            'required_constructor' => 'public function __construct(string $name) {}',
+        ]);
+        $invalidConstructors->each(function (string $constructor, string $name): void {
+            (new AddOnScaffoldService($this->workspace))->generate($name, $name);
+            $registration = $this->workspace . "/{$name}/logic/Registration/AddOnRegistration.php";
+            file_put_contents(
+                $registration,
+                Str::make((string) FileSystem::fileContents($registration))
+                    ->replace(
+                        "final class AddOnRegistration\n{",
+                        "final class AddOnRegistration\n{\n    {$constructor}"
+                    )
+                    ->val()
+            );
+
+            $result = (new AddOnContractValidator())->validate($this->workspace . "/{$name}");
+            $codes = Arr::make($result['errors'])
+                ->map(fn (array $error): string => (string) Arr::make($error)->get('code'))
+                ->val();
+
+            $this->assertFalse($result['valid']);
+            $this->assertContains('registration_class', $codes);
+        });
+
+        (new AddOnScaffoldService($this->workspace))->generate('optional_constructor', 'optional_constructor');
+        $registration = $this->workspace
+            . '/optional_constructor/logic/Registration/AddOnRegistration.php';
+        file_put_contents(
+            $registration,
+            Str::make((string) FileSystem::fileContents($registration))
+                ->replace(
+                    "final class AddOnRegistration\n{",
+                    "final class AddOnRegistration\n{\n"
+                        . "    public function __construct(string \$name = 'default') {}"
+                )
+                ->val()
+        );
+
+        $result = (new AddOnContractValidator())->validate($this->workspace . '/optional_constructor');
+
+        $this->assertTrue($result['valid'], Arr::make($result['errors'])->toJson());
     }
 
     public function testRegistrationFactoryRejectsTopLevelExecution(): void

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -415,6 +415,29 @@ PHP
         $this->assertContains('registration_factory', $codes);
     }
 
+    public function testRegistrationFactoryHonorsImportedAliases(): void
+    {
+        (new AddOnScaffoldService($this->workspace))->generate('factory_alias', 'factory_alias');
+        $main = $this->workspace . '/factory_alias/main.php';
+        file_put_contents(
+            $main,
+            Str::make((string) FileSystem::fileContents($main))
+                ->replace(
+                    'use AddOns\\FactoryAlias\\Registration\\AddOnRegistration;',
+                    'use AddOns\\FactoryAlias\\Registration\\AddOnRegistration as RenamedRegistration;'
+                )
+                ->val()
+        );
+
+        $result = (new AddOnContractValidator())->validate($this->workspace . '/factory_alias');
+        $codes = Arr::make($result['errors'])
+            ->map(fn (array $error): string => (string) Arr::make($error)->get('code'))
+            ->val();
+
+        $this->assertFalse($result['valid']);
+        $this->assertContains('registration_factory', $codes);
+    }
+
     public function testItAcceptsSupportedExecutableMappings(): void
     {
         (new AddOnScaffoldService($this->workspace))->generate('mapped', 'mapped');
@@ -438,6 +461,10 @@ Mapping::add('/nested', static function (): array {
 
     return $inner();
 }, 'nested', 'get');
+Mapping::add('/nested-arrow', static fn (): array => helper(
+    static fn (): array => [],
+    service('items')
+), 'nested-arrow', 'get');
 PHP
         );
 

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -559,6 +559,30 @@ PHP
         $this->assertTrue($result['valid'], Arr::make($result['errors'])->toJson());
     }
 
+    public function testItAcceptsInterpolatedStringsInsideDeferredMappings(): void
+    {
+        (new AddOnScaffoldService($this->workspace))->generate('interpolation', 'interpolation');
+        file_put_contents(
+            $this->workspace . '/interpolation/mapping/api.php',
+            <<<'PHP'
+<?php
+
+use BlueFission\Services\Mapping;
+
+Mapping::add(
+    '/hello',
+    static fn (string $name): string => "Hello {$name}",
+    'hello',
+    'get'
+);
+PHP
+        );
+
+        $result = (new AddOnContractValidator())->validate($this->workspace . '/interpolation');
+
+        $this->assertTrue($result['valid'], Arr::make($result['errors'])->toJson());
+    }
+
     public function testExecutableMappingsRequireTheShortNameImport(): void
     {
         (new AddOnScaffoldService($this->workspace))->generate('missing_import', 'missing_import');

--- a/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
@@ -263,6 +263,23 @@ PHP
         $this->assertCount(2, $mappingErrors->val());
     }
 
+    public function testItRejectsShellExpressionsInDeclarativeMappings(): void
+    {
+        (new AddOnScaffoldService($this->workspace))->generate('shell', 'shell');
+        file_put_contents(
+            $this->workspace . '/shell/mapping/api.php',
+            "<?php\nreturn [`echo unsafe`];\n"
+        );
+
+        $result = (new AddOnContractValidator())->validate($this->workspace . '/shell');
+        $codes = Arr::make($result['errors'])
+            ->map(fn (array $error): string => (string) Arr::make($error)->get('code'))
+            ->val();
+
+        $this->assertFalse($result['valid']);
+        $this->assertContains('mapping_contract', $codes);
+    }
+
     public function testItAcceptsSupportedExecutableMappings(): void
     {
         (new AddOnScaffoldService($this->workspace))->generate('mapped', 'mapped');


### PR DESCRIPTION
## Intent

Provide one canonical, application-owned add-on scaffold and validator so add-on packages can be generated with a consistent lifecycle-safe layout, namespace contract, template boundary, and isolated bootstrap surface.

Refs #43.

## User Stories And Acceptance Criteria

- Generate a canonical add-on package from a lowercase lifecycle key.
- Map `AddOns\\PackageName\\` to `logic/` with Business, Domain, Registration, mapping, resource, datasource, and test layers.
- Validate package metadata, declared registration and theme entrypoints, required paths, PHP syntax and namespaces, supported mapping contracts, and `.vibe` template syntax without booting the application.
- Keep menu registration safe when no navigation service is available.
- Refuse parent traversal, destinations outside the workspace, and replacement of existing output.
- Validate the temporary package before publishing it through an atomic no-clobber reservation.
- Resolve test autoloading for standalone packages and application-root installations.

## Key Files

- `app/Business/Services/AddOnScaffoldService.php`
- `app/Business/Services/AddOnContractValidator.php`
- `bin/opus-addon.php`
- `tests/Unit/Business/Services/AddOnScaffoldServiceTest.php`
- `ADDONS.md`

## How To Test

```shell
vendor/bin/phpunit --do-not-cache-result tests/Unit/Business/Services/AddOnScaffoldServiceTest.php
vendor/bin/phpunit --do-not-cache-result
php bin/opus-addon.php generate sample_tools addons/sample_tools
php bin/opus-addon.php validate addons/sample_tools
composer validate --strict --no-check-lock
composer check-platform-reqs
```

Local proof:

- Focused tests: 24 tests, 70 assertions.
- Full suite: 98 tests, 568 assertions, 3 expected platform skips.
- Generated package passes strict Composer manifest validation, PHP lint, and the Opus add-on validator.
- Root Composer validation and platform requirements pass. The root manifest retains its existing non-SPDX license warning.
- Composer audit completed and retains the existing advisories tracked in #41; this PR does not change dependency versions.
- The full suite exits successfully but retains the existing post-summary Windows `link()` diagnostic tracked in #10.

## QA Checklist

- [x] PHP 8.2-compatible strict types used for new runtime files.
- [x] DevElation service, array, string, and filesystem surfaces used at application boundaries.
- [x] No add-on PHP is executed during validation.
- [x] Generated menu mapping loads without a navigation service.
- [x] Generated registration and primary factory load in isolation.
- [x] Existing destinations and unsafe paths are rejected.
- [x] Documentation describes migration from root-level PSR-4 mappings.
- [x] Composer dependency audit result is accounted for in #41.

## Approval Conditions

- Confirm the canonical layout and `AddOns\\PackageName\\` to `logic/` namespace convention.
- Confirm that lifecycle execution remains owned by the existing lifecycle issues rather than this scaffold slice.
- Confirm CI and review feedback are resolved before the PR leaves draft.
- Confirm declarative and established executable mapping forms remain package-owned contracts.
