### PR TITLE
Align consumer modules with DevElation value helpers

### DIFF
--- a/app/Business/Commands/UserResource.php
+++ b/app/Business/Commands/UserResource.php
@@ -5,6 +5,7 @@ namespace App\Business\Commands;
 use BlueFission\Services\Service;
 use App\Domain\User\Repositories\UserRepositorySql;
 use BlueFission\BlueCore\Auth as Authenticator;
+use BlueFission\Arr;
 use BlueFission\Str;
 use App\Business\Http\Api\Admin\UserController;
 
@@ -56,7 +57,7 @@ class UserResource extends Service
                 break;
 
             case 'list':
-                if ( count($args) > 0) {
+                if (Arr::make($args)->isNotEmpty()) {
                     $this->listProperties();
                 } elseif ($this->isAdmin()) {
                     $this->_response = $this->listUsers();
@@ -131,7 +132,7 @@ class UserResource extends Service
     {
         if ($this->authenticator->isAuthenticated()) {
             $user = $this->userRepository->find(USER_ID);
-            $properties = implode(', ', array_keys($user['data']));
+            $properties = Arr::make($user['data'])->keys()->join(', ')->val();
             $this->_response = "The following properties are available: {$properties}.";
         } else {
             $this->_response = "User is not authenticated.";
@@ -176,8 +177,9 @@ class UserResource extends Service
     {
         if ($this->isAdmin()) {
             $users = $this->userRepository->all();
-            $usernames = array_column($users, 'username');
-            $this->_response = "Usernames:\n" . implode("\n", $usernames);
+            $usernames = Arr::make($users)
+                ->map(fn (array $user) => Arr::make($user)->get('username'));
+            $this->_response = "Usernames:\n" . $usernames->join("\n")->val();
         } else {
             $this->_response = "User is not authenticated.";
         }
@@ -194,7 +196,8 @@ class UserResource extends Service
             $user = $this->userRepository->find($args[0]);
 
             if ($user) {
-                $this->_response = "Username: {$user['username']}\nGoals:\n" . implode("\n", $user['goals']);
+                $this->_response = "Username: {$user['username']}\nGoals:\n"
+                    . Arr::make($user['goals'])->join("\n")->val();
             } else {
                 $this->_response = "User not found.";
             }

--- a/app/Business/Console/BotMan/CommandLineDriver.php
+++ b/app/Business/Console/BotMan/CommandLineDriver.php
@@ -11,6 +11,7 @@ use BotMan\BotMan\Messages\Outgoing\Question;
 use BotMan\BotMan\Messages\Outgoing\Actions\Button;
 use BotMan\BotMan\Users\User;
 use BlueFission\HTML\HTML;
+use BlueFission\Str;
 
 class CommandLineDriver extends HttpDriver
 {
@@ -91,7 +92,7 @@ class CommandLineDriver extends HttpDriver
         }
 
         // echo '> ';
-        $input = trim(fgets(STDIN));
+        $input = Str::trim((string) fgets(STDIN));
 
         // Check if the input is a number and corresponds to a button
         if (is_numeric($input) && isset($buttons[$input - 1])) {

--- a/app/Business/Console/CliManager.php
+++ b/app/Business/Console/CliManager.php
@@ -3,6 +3,7 @@ namespace App\Business\Console;
 
 use BotMan\BotMan\BotMan;
 use BlueFission\Services\Service;
+use BlueFission\Str;
 use App\Business\Console\BotMan\CommandLineDriver;
 // use BlueFission\Wise\Cmd\CommandProcessor;
 
@@ -25,7 +26,7 @@ class CliManager extends Service {
 		$last_line = false;
 		$message = '';
 		while (!$last_line) {
-		    $next_line = trim(fgets($fp, 1024)); // read the special file to get the user input from keyboard
+		    $next_line = Str::trim((string) fgets($fp, 1024)); // read the special file to get the user input from keyboard
 		    if ("." == $next_line) {
 		      $last_line = true;
 		    } else {
@@ -66,7 +67,7 @@ class CliManager extends Service {
         	printf("%c%c",0x08,0x08);
 			echo "\e[0m> ";
 
-	        $next_line = trim(fgets($fp, 1024)); // read the special file to get the user input from keyboard
+	        $next_line = Str::trim((string) fgets($fp, 1024)); // read the special file to get the user input from keyboard
 	        if ("." == $next_line) {
 	            $last_line = true;
 	        } else {

--- a/app/Business/Console/SocketManager.php
+++ b/app/Business/Console/SocketManager.php
@@ -2,6 +2,7 @@
 // https://nomadphp.com/blog/92/build-a-chat-system-with-php-sockets-and-w3c-web-sockets-apis
 namespace App\Business\Console;
 
+use BlueFission\Net\HTTP;
 use BlueFission\Services\Service;
 
 class SocketManager extends Service {
@@ -35,7 +36,7 @@ class SocketManager extends Service {
 				$socket_new = socket_accept($socket);	$clients[] = $socket_new; 
 				$header = socket_read($socket_new, 1024);
 				$this->perform_handshaking($header, $socket_new, $host, $port); 
-				socket_getpeername($socket_new, $ip);	$response = $this->mask(json_encode(array('type'=>'system', 'message'=>$ip.' connected')));
+				socket_getpeername($socket_new, $ip);	$response = $this->mask(HTTP::jsonEncode(['type'=>'system', 'message'=>$ip.' connected']));
 				$this->send_message($response); 
 				$found_socket = array_search($socket, $changed);
 				unset($changed[$found_socket]);
@@ -45,8 +46,8 @@ class SocketManager extends Service {
 
 				while(socket_recv($changed_socket, $buf, 1024, 0) >= 1)
 				{
-					$received_text = $this->unmask($buf);	$tst_msg = json_decode($received_text, true);	$user_name = $tst_msg['name'];	$user_message = $tst_msg['message'];	$user_color = $tst_msg['color']; 
-					$response_text = $this->mask(json_encode(array('type'=>'usermsg', 'name'=>$user_name, 'message'=>$user_message, 'color'=>$user_color)));
+					$received_text = $this->unmask($buf);	$tst_msg = HTTP::jsonDecode($received_text, true);	$user_name = $tst_msg['name'];	$user_message = $tst_msg['message'];	$user_color = $tst_msg['color'];
+					$response_text = $this->mask(HTTP::jsonEncode(['type'=>'usermsg', 'name'=>$user_name, 'message'=>$user_message, 'color'=>$user_color]));
 					send_message($response_text);	break 2;	
 				}
 
@@ -56,7 +57,7 @@ class SocketManager extends Service {
 					socket_getpeername($changed_socket, $ip);
 					unset($clients[$found_socket]);
 
-					$response = $this->mask(json_encode(array('type'=>'system', 'message'=>$ip.' disconnected')));
+					$response = $this->mask(HTTP::jsonEncode(['type'=>'system', 'message'=>$ip.' disconnected']));
 					$this->send_message($response);
 				}
 			}
@@ -76,6 +77,7 @@ class SocketManager extends Service {
 	}
 	
 	private function unmask($text) {
+		// WebSocket frame offsets and lengths are byte-level protocol operations.
 		$length = ord($text[1]) & 127;
 		if($length == 126) {
 			$masks = substr($text, 4, 4);

--- a/app/Business/Databases/Pinecone.php
+++ b/app/Business/Databases/Pinecone.php
@@ -3,6 +3,7 @@ namespace App\Business\Databases;
 
 use BlueFission\Data\Storage\Storage;
 use BlueFission\Connections\Curl;
+use BlueFission\Net\HTTP;
 
 // https://betterprogramming.pub/enhancing-chatgpt-with-infinite-external-memory-using-vector-database-and-chatgpt-retrieval-plugin-b6f4ea16ab8
 class Pinecone extends Storage
@@ -51,7 +52,7 @@ class Pinecone extends Storage
         $response = $this->client->result();
         $this->client->close();
 
-        return json_decode($response, true);
+        return HTTP::jsonDecode((string) $response, true);
     }
 
     public function createIndex($metric = "cosine")

--- a/app/Business/Http/Api/Admin/AddOnController.php
+++ b/app/Business/Http/Api/Admin/AddOnController.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Business\Http\Api\Admin;
 
+use BlueFission\Arr;
 use BlueFission\Services\Service;
 use BlueFission\Services\Request;
 use BlueFission\Connections\Database\MySQLLink;
@@ -23,7 +24,7 @@ class AddOnController extends Service {
             $addons[$addon['name']]->is_active = $addon['is_active'];
         }
 
-        $list = array_values($addons);
+        $list = Arr::make($addons)->values()->val();
 
         return response($list);
     }

--- a/app/Business/Managers/ZapManager.php
+++ b/app/Business/Managers/ZapManager.php
@@ -1,6 +1,8 @@
 <?php
 namespace App\Business\Managers;
 
+use BlueFission\Net\HTTP;
+
 class ZapManager {
     private $apiKey;
     private $apiUrl = 'https://api.zapier.com/v1/';
@@ -16,7 +18,7 @@ class ZapManager {
             'http' => [
                 'header'  => "Content-Type: application/json\r\nAuthorization: Basic " . base64_encode($this->apiKey . ":"),
                 'method'  => $method,
-                'content' => json_encode($data)
+                'content' => HTTP::jsonEncode($data)
             ]
         ];
 
@@ -26,7 +28,7 @@ class ZapManager {
             throw new \Exception('Error calling Zapier API: ' . $http_response_header[0]);
         }
 
-        return json_decode($result, true);
+        return HTTP::jsonDecode($result, true);
     }
 
     public function searchZaps($query) {

--- a/app/Business/Middleware/HearsIntentMiddleware.php
+++ b/app/Business/Middleware/HearsIntentMiddleware.php
@@ -9,6 +9,9 @@ use BotMan\BotMan\Messages\Incoming\IncomingMessage;
 use BotMan\BotMan\Messages\Outgoing\OutgoingMessage;
 use BlueFission\Automata\Intent\Matcher;
 use BlueFission\Automata\Context;
+use BlueFission\Arr;
+use BlueFission\Net\HTTP;
+use BlueFission\Str;
 
 class HearsIntentMiddleware implements Received, Sending
 {
@@ -56,11 +59,11 @@ class HearsIntentMiddleware implements Received, Sending
 
     protected function replyWithSkillResponse(BotMan $bot, $response)
     {
-        if (is_string($response) && $response != "") {
+        if (Str::is($response) && Str::make($response)->isNotEmpty()) {
             $bot->reply($response);
-        } elseif (is_array($response)) {
+        } elseif (Arr::is($response)) {
             // If the response is an array, you can convert it to JSON or handle it differently based on your needs
-            $bot->reply(json_encode($response));
+            $bot->reply(HTTP::jsonEncode($response));
         } else {
             // Handle other response types if necessary
         }

--- a/app/Business/Preparers/SimpleSentenceEmbeddings.php
+++ b/app/Business/Preparers/SimpleSentenceEmbeddings.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Business\Preparers;
 
+use BlueFission\Arr;
 use Phpml\Tokenization\WhitespaceTokenizer;
 use Phpml\Vectorization\Word2Vec;
 
@@ -31,19 +32,20 @@ class SimpleSentenceEmbeddings
     {
         $tokenizer = new WhitespaceTokenizer();
         $tokens = $tokenizer->tokenize($sentence);
-        $wordVectors = [];
+        $wordVectors = Arr::make([]);
 
         foreach ($tokens as $token) {
             if (isset($this->model->vocabulary[$token])) {
-                $wordVectors[] = $this->model->getVector($token);
+                $wordVectors->push($this->model->getVector($token));
             }
         }
 
-        if (count($wordVectors) == 0) {
+        // The model API and numeric reduction operate on raw vector arrays.
+        if ($wordVectors->isEmpty()) {
             return array_fill(0, $this->model->dimensions, 0.0);
         }
 
-        $sentenceVector = array_reduce($wordVectors, function ($carry, $item) {
+        $sentenceVector = array_reduce($wordVectors->val(), function ($carry, $item) {
             foreach ($item as $key => $value) {
                 $carry[$key] += $value;
             }
@@ -51,7 +53,7 @@ class SimpleSentenceEmbeddings
         }, array_fill(0, $this->model->dimensions, 0.0));
 
         foreach ($sentenceVector as $key => $value) {
-            $sentenceVector[$key] /= count($wordVectors);
+            $sentenceVector[$key] /= $wordVectors->count();
         }
 
         return $sentenceVector;
@@ -63,7 +65,7 @@ class SimpleSentenceEmbeddings
         $embeddedChunks = [];
 
         foreach ($chunkedSentences as $chunk) {
-            $embeddedChunks[] = $this->embedSentence(implode(' ', $chunk));
+            $embeddedChunks[] = $this->embedSentence(Arr::make($chunk)->join(' ')->val());
         }
 
         return $embeddedChunks;
@@ -71,14 +73,15 @@ class SimpleSentenceEmbeddings
 
     private function chunkSentences(array $sentences): array
     {
-        $chunkedSentences = [];
-        $count = count($sentences);
+        $chunkedSentences = Arr::make([]);
+        $sentences = Arr::make($sentences);
+        $count = $sentences->count();
 
         for ($i = 0; $i < $count; $i += $this->chunkSize - $this->overlap) {
-            $chunkedSentences[] = array_slice($sentences, $i, $this->chunkSize);
+            $chunkedSentences->push($sentences->slice($i, $this->chunkSize)->val());
         }
 
-        return $chunkedSentences;
+        return $chunkedSentences->val();
     }
 }
 

--- a/app/Business/Services/EnvironmentLoader.php
+++ b/app/Business/Services/EnvironmentLoader.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Business\Services;
 
+use BlueFission\Str;
+
 final class EnvironmentLoader
 {
     public static function import(string $file): void
@@ -14,24 +16,24 @@ final class EnvironmentLoader
         }
 
         foreach ($variables as $variable) {
-            $variable = trim($variable);
-            if ($variable === '' || str_starts_with($variable, '#')) {
+            $variable = Str::make($variable)->trim();
+            if ($variable->isEmpty() || $variable->startsWith('#')) {
                 continue;
             }
 
-            $separator = strpos($variable, '=');
-            if ($separator === false) {
+            $parts = $variable->split('=');
+            if ($parts->count() < 2) {
                 continue;
             }
 
-            $name = trim(substr($variable, 0, $separator));
-            if ($name === '') {
+            $name = Str::make((string) $parts->shift())->trim();
+            if ($name->isEmpty()) {
                 continue;
             }
 
-            $value = trim(substr($variable, $separator + 1));
-            putenv($name . '=' . $value);
-            $_ENV[$name] = $value;
+            $value = $parts->join('=')->trim()->val();
+            putenv($name->val() . '=' . $value);
+            $_ENV[$name->val()] = $value;
         }
     }
 }

--- a/app/Business/Services/ProjectPathResolver.php
+++ b/app/Business/Services/ProjectPathResolver.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Business\Services;
 
+use BlueFission\Str;
+
 final class ProjectPathResolver
 {
     public static function resolve(
@@ -13,7 +15,10 @@ final class ProjectPathResolver
     ): string {
         $applicationRoot = rtrim($applicationRoot, '/\\');
         $projectRoot = rtrim($projectRoot, '/\\');
-        $pathInProject = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $pathInProject);
+        $pathInProject = Str::make($pathInProject)
+            ->replace('/', DIRECTORY_SEPARATOR)
+            ->replace('\\', DIRECTORY_SEPARATOR)
+            ->val();
 
         $candidate = $applicationRoot . DIRECTORY_SEPARATOR . $pathInProject;
         $fallback = $projectRoot . DIRECTORY_SEPARATOR . $pathInProject;
@@ -22,7 +27,8 @@ final class ProjectPathResolver
             return $candidate;
         }
 
-        if (strpbrk($pathInProject, '*?[') !== false) {
+        $path = Str::make($pathInProject);
+        if ($path->contains('*') || $path->contains('?') || $path->contains('[')) {
             $matches = glob($candidate);
             if ($matches !== false && $matches !== []) {
                 return $candidate;

--- a/app/Business/Services/RuntimeContractProofService.php
+++ b/app/Business/Services/RuntimeContractProofService.php
@@ -6,6 +6,7 @@ namespace App\Business\Services;
 
 use BlueFission\Arr;
 use BlueFission\Data\FileSystem;
+use BlueFission\Net\HTTP;
 use BlueFission\Services\Service;
 use BlueFission\Str;
 use RuntimeException;
@@ -203,7 +204,7 @@ class RuntimeContractProofService extends Service
             throw new RuntimeException("Runtime contract manifest could not be read.");
         }
 
-        $decoded = json_decode($contents, true);
+        $decoded = HTTP::jsonDecode($contents, true);
         if (!Arr::is($decoded)) {
             throw new RuntimeException("Runtime contract manifest is not valid JSON.");
         }

--- a/app/Business/Services/VibeGenerationService.php
+++ b/app/Business/Services/VibeGenerationService.php
@@ -226,6 +226,7 @@ class VibeGenerationService extends Service
             return false;
         }
 
+        // Keep byte offsets native at this low-level stream boundary.
         $offset = 0;
         $length = strlen($contents);
         while ($offset < $length) {

--- a/tests/Unit/Business/Services/VibeGenerationServiceTest.php
+++ b/tests/Unit/Business/Services/VibeGenerationServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Business\Services;
 
 use App\Business\Services\VibeGenerationService;
+use BlueFission\Arr;
 use BlueFission\Data\FileSystem;
 use BlueFission\Str;
 use PHPUnit\Framework\TestCase;
@@ -29,8 +30,8 @@ class VibeGenerationServiceTest extends TestCase
             'kernel' => 'Wise',
         ]);
 
-        $this->assertTrue($result['valid'], json_encode($result['errors']));
-        $this->assertSame('Opus kernel: Wise', trim($result['output']));
+        $this->assertTrue($result['valid'], Arr::make($result['errors'])->toJson());
+        $this->assertSame('Opus kernel: Wise', Str::make($result['output'])->trim()->val());
         $this->assertSame('Wise', $result['variables']['kernel'] ?? null);
     }
 
@@ -48,9 +49,12 @@ class VibeGenerationServiceTest extends TestCase
             'agent' => 'ready',
         ]);
 
-        $this->assertTrue($result['valid'], json_encode($result['errors']));
+        $this->assertTrue($result['valid'], Arr::make($result['errors'])->toJson());
         $this->assertTrue(FileSystem::fileExists($target));
-        $this->assertSame('Add-on agent: ready', trim((string) FileSystem::fileContents($target)));
+        $this->assertSame(
+            'Add-on agent: ready',
+            Str::make((string) FileSystem::fileContents($target))->trim()->val()
+        );
 
         unlink($source);
         unlink($target);
@@ -116,7 +120,7 @@ class VibeGenerationServiceTest extends TestCase
         try {
             $result = $service->writeRenderedFile($source, $target);
 
-            $this->assertTrue($result['valid'], json_encode($result['errors']));
+            $this->assertTrue($result['valid'], Arr::make($result['errors'])->toJson());
             $this->assertSame('Replacement content', FileSystem::fileContents($target));
             $this->assertSame('Outside original', FileSystem::fileContents($outside));
         } finally {
@@ -151,7 +155,7 @@ class VibeGenerationServiceTest extends TestCase
 
         $result = $service->writeRenderedFile($source, $target);
 
-        $this->assertTrue($result['valid'], json_encode($result['errors']));
+        $this->assertTrue($result['valid'], Arr::make($result['errors'])->toJson());
         $this->assertSame(0644, fileperms($target) & 0777);
 
         unlink($source);
@@ -222,7 +226,7 @@ class VibeGenerationServiceTest extends TestCase
             chdir($originalDirectory);
         }
 
-        $this->assertTrue($result['valid'], json_encode($result['errors']));
+        $this->assertTrue($result['valid'], Arr::make($result['errors'])->toJson());
         $this->assertSame($expectedTarget, $result['path']);
         $this->assertTrue(FileSystem::fileExists($expectedTarget));
 
@@ -246,7 +250,7 @@ class VibeGenerationServiceTest extends TestCase
 
         $result = $service->writeRenderedFile($source, $target);
 
-        $this->assertTrue($result['valid'], json_encode($result['errors']));
+        $this->assertTrue($result['valid'], Arr::make($result['errors'])->toJson());
         $this->assertTrue(FileSystem::fileExists($target));
 
         unlink($source);

--- a/tests/Unit/Business/Services/VibeThemeSourceTest.php
+++ b/tests/Unit/Business/Services/VibeThemeSourceTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Business\Services;
 
+use BlueFission\Data\FileSystem;
+use BlueFission\Net\HTTP;
+use BlueFission\Str;
 use BlueFission\Vibrato\Reader;
 use BlueFission\Vibrato\Validation\VibeSyntaxValidator;
 use PHPUnit\Framework\TestCase;
@@ -46,13 +49,13 @@ final class VibeThemeSourceTest extends TestCase
         $validator = new VibeSyntaxValidator();
 
         foreach ($this->vibeFiles() as $file) {
-            $source = file_get_contents($file->getPathname());
+            $source = FileSystem::fileContents($file->getPathname());
             $this->assertIsString($source);
 
             $result = $validator->validate($source);
             $this->assertTrue(
                 $result->isValid(),
-                $file->getPathname() . ': ' . json_encode($result->errors(), JSON_UNESCAPED_SLASHES)
+                $file->getPathname() . ': ' . HTTP::jsonEncode($result->errors())
             );
         }
     }
@@ -109,7 +112,7 @@ final class VibeThemeSourceTest extends TestCase
     {
         $htmlFiles = [];
         foreach ($this->allThemeFiles() as $file) {
-            if (strtolower($file->getExtension()) === 'html') {
+            if (Str::lower($file->getExtension()) === 'html') {
                 $htmlFiles[] = $file->getPathname();
             }
         }
@@ -122,7 +125,7 @@ final class VibeThemeSourceTest extends TestCase
     {
         $files = [];
         foreach ($this->allThemeFiles() as $file) {
-            if (strtolower($file->getExtension()) === 'vibe') {
+            if (Str::lower($file->getExtension()) === 'vibe') {
                 $files[] = $file;
             }
         }
@@ -153,7 +156,7 @@ final class VibeThemeSourceTest extends TestCase
     {
         foreach (['admin', 'default'] as $theme) {
             $themeDirectory = $this->markupDirectory . DIRECTORY_SEPARATOR . $theme;
-            if (str_starts_with($path, $themeDirectory . DIRECTORY_SEPARATOR)) {
+            if (Str::startsWith($path, $themeDirectory . DIRECTORY_SEPARATOR)) {
                 return $themeDirectory;
             }
         }

--- a/tests/Unit/ComposerMetadataTest.php
+++ b/tests/Unit/ComposerMetadataTest.php
@@ -4,18 +4,21 @@ declare(strict_types=1);
 
 namespace Tests\Unit;
 
+use BlueFission\Data\FileSystem;
+use BlueFission\Net\HTTP;
 use PHPUnit\Framework\TestCase;
 
 class ComposerMetadataTest extends TestCase
 {
     public function testRatchetWebSocketTransportIsOptional(): void
     {
-        $contents = file_get_contents(__DIR__ . '/../../composer.json');
+        $contents = FileSystem::fileContents(__DIR__ . '/../../composer.json');
 
-        $this->assertNotFalse($contents);
+        $this->assertIsString($contents);
 
-        $composer = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        $composer = HTTP::jsonDecode($contents, true, []);
 
+        $this->assertIsArray($composer);
         $this->assertArrayNotHasKey('cboden/ratchet', $composer['require'] ?? []);
         $this->assertArrayHasKey('cboden/ratchet', $composer['suggest'] ?? []);
     }

--- a/tests/Unit/DevElationHelperUsageTest.php
+++ b/tests/Unit/DevElationHelperUsageTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use BlueFission\Arr;
+use BlueFission\Data\FileSystem;
+use BlueFission\Str;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+final class DevElationHelperUsageTest extends TestCase
+{
+    private const FORBIDDEN_APPLICATION_HELPERS = [
+        'json_encode' => 'native JSON helper',
+        'json_decode' => 'native JSON helper',
+        'array_keys' => 'native array inspection helper',
+        'array_column' => 'native array inspection helper',
+        'array_values' => 'native array inspection helper',
+        'is_array' => 'native array inspection helper',
+        'str_replace' => 'native string transformation helper',
+        'strtolower' => 'native string transformation helper',
+        'strtoupper' => 'native string transformation helper',
+        'str_starts_with' => 'native string transformation helper',
+        'str_ends_with' => 'native string transformation helper',
+        'trim' => 'native string normalization helper',
+        'strpos' => 'native string inspection helper',
+        'explode' => 'native string splitting helper',
+        'implode' => 'native array joining helper',
+        'count' => 'native array counting helper',
+        'compact' => 'native array construction helper',
+    ];
+
+    public function testApplicationCodeUsesPackageOwnedValueHelpers(): void
+    {
+        $violations = Arr::make([]);
+        $forbidden = Arr::make(self::FORBIDDEN_APPLICATION_HELPERS);
+        $root = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'app';
+        $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root));
+
+        foreach ($iterator as $file) {
+            if (!$file instanceof SplFileInfo || !$file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $source = FileSystem::fileContents($file->getPathname());
+            if (!Str::is($source)) {
+                $violations->push($file->getPathname() . ': unreadable');
+                continue;
+            }
+
+            $tokens = Arr::make(token_get_all($source));
+            foreach ($tokens as $index => $token) {
+                if (!Arr::is($token) || Arr::make($token)->get(0) !== T_STRING) {
+                    continue;
+                }
+
+                $name = Str::lower((string) Arr::make($token)->get(1));
+                $previous = $this->previousToken($tokens, $index);
+                if (!$forbidden->hasKey($name)
+                    || $this->nextToken($tokens, $index) !== '('
+                    || (Arr::is($previous) && Arr::make([
+                        T_DOUBLE_COLON,
+                        T_OBJECT_OPERATOR,
+                        T_NULLSAFE_OBJECT_OPERATOR,
+                    ])->has(Arr::make($previous)->get(0), true))
+                ) {
+                    continue;
+                }
+
+                $violations->push(
+                    $file->getPathname() . ': ' . $forbidden->get($name) . ' (' . $name . ')'
+                );
+            }
+        }
+
+        $this->assertSame([], $violations->val(), $violations->join(PHP_EOL)->val());
+    }
+
+    private function nextToken(Arr $tokens, int $index): mixed
+    {
+        for ($offset = $index + 1; $offset < $tokens->count(); $offset++) {
+            $token = $tokens->get($offset);
+            if (Arr::is($token) && Arr::make([T_WHITESPACE, T_COMMENT, T_DOC_COMMENT])->has(
+                Arr::make($token)->get(0),
+                true
+            )) {
+                continue;
+            }
+
+            return $token;
+        }
+
+        return null;
+    }
+
+    private function previousToken(Arr $tokens, int $index): mixed
+    {
+        for ($offset = $index - 1; $offset >= 0; $offset--) {
+            $token = $tokens->get($offset);
+            if (Arr::is($token) && Arr::make([T_WHITESPACE, T_COMMENT, T_DOC_COMMENT])->has(
+                Arr::make($token)->get(0),
+                true
+            )) {
+                continue;
+            }
+
+            return $token;
+        }
+
+        return null;
+    }
+}

--- a/tests/Unit/RuntimeContractProofServiceTest.php
+++ b/tests/Unit/RuntimeContractProofServiceTest.php
@@ -111,4 +111,27 @@ class RuntimeContractProofServiceTest extends TestCase
 
         $service->manifest();
     }
+
+    public function testInvalidJsonManifestRaisesAContractError(): void
+    {
+        $root = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'opus-invalid-manifest-'
+            . bin2hex(random_bytes(8));
+        $directory = $root . DIRECTORY_SEPARATOR . 'examples' . DIRECTORY_SEPARATOR . 'jenss';
+        mkdir($directory, 0777, true);
+        file_put_contents($directory . DIRECTORY_SEPARATOR . 'runtime-contract-proof.json', '{invalid');
+
+        try {
+            $service = new RuntimeContractProofService($root);
+
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('Runtime contract manifest is not valid JSON.');
+
+            $service->manifest();
+        } finally {
+            unlink($directory . DIRECTORY_SEPARATOR . 'runtime-contract-proof.json');
+            rmdir($directory);
+            rmdir(dirname($directory));
+            rmdir($root);
+        }
+    }
 }

--- a/tests/Unit/TerminalBootstrapOrderTest.php
+++ b/tests/Unit/TerminalBootstrapOrderTest.php
@@ -4,15 +4,18 @@ declare(strict_types=1);
 
 namespace Tests\Unit;
 
+use BlueFission\Data\FileSystem;
+use BlueFission\Str;
 use PHPUnit\Framework\TestCase;
 
 class TerminalBootstrapOrderTest extends TestCase
 {
     public function testComposerLoadsBeforeApplicationSettings(): void
     {
-        $terminal = file_get_contents(dirname(__DIR__, 2) . '/terminal');
-        $autoload = strpos($terminal, "require 'vendor/autoload.php';");
-        $settings = strpos($terminal, "require 'common/helpers/settings.php';");
+        $terminal = FileSystem::fileContents(dirname(__DIR__, 2) . '/terminal');
+        $this->assertIsString($terminal);
+        $autoload = Str::pos($terminal, "require 'vendor/autoload.php';");
+        $settings = Str::pos($terminal, "require 'common/helpers/settings.php';");
 
         $this->assertNotFalse($autoload);
         $this->assertNotFalse($settings);


### PR DESCRIPTION
## Intent

Align existing Opus consumer modules with the repository's DevElation primitive and network-helper standards while preserving native operations at low-level protocol, stream, and numeric-vector boundaries.

Closes #46.

## User Stories And Acceptance Criteria

- Application JSON boundaries use the package-owned HTTP helpers.
- Carried string parsing and normalization use `Str`.
- Collection inspection, projection, joining, slicing, and counting use `Arr` where return semantics remain compatible.
- Binary WebSocket framing, stream byte offsets, and external numeric-vector reduction retain native operations with explicit boundary comments.
- Invalid runtime manifests retain their contract error.
- A token-aware regression guard rejects replaceable native helpers in application code without flagging method or static-helper calls.

## Key Files

- `app/Business/Services/EnvironmentLoader.php`
- `app/Business/Services/RuntimeContractProofService.php`
- `app/Business/Preparers/SimpleSentenceEmbeddings.php`
- `app/Business/Middleware/HearsIntentMiddleware.php`
- `tests/Unit/DevElationHelperUsageTest.php`
- `tests/Unit/RuntimeContractProofServiceTest.php`

## How To Test

```shell
vendor/bin/phpunit --do-not-cache-result
composer validate --strict --no-check-lock
composer check-platform-reqs
composer audit --locked
```

Local proof:

- Full suite: 76 tests, 503 assertions, 3 expected platform skips.
- PHP lint passes for every changed PHP file.
- Composer platform requirements pass.
- Strict Composer validation retains the existing non-SPDX `Exclusive` license warning tracked in #16.
- Composer audit retains the three existing Guzzle/PHP-JWT advisories tracked in #41.
- The full suite exits successfully but retains the existing post-summary Windows `link()` diagnostic tracked in #10.

## QA Checklist

- [x] Public return contracts remain unchanged.
- [x] Invalid JSON behavior is covered.
- [x] Values containing `=` remain supported by environment parsing.
- [x] Low-level native-operation exceptions are explicit.
- [x] The regression guard tokenizes PHP and ignores comments, strings, and object/static method calls.
- [x] No dependency versions or environment values changed.

## Approval Conditions

- Confirm the selected helper replacements preserve existing semantics.
- Confirm the low-level boundary exceptions remain appropriate.
- Confirm the token-aware guard is narrow enough for package implementation boundaries.
