### PR TITLE
Resolve locked JWT security advisory

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -93,6 +93,20 @@ Acceptance criteria:
 - Legacy dashboard modules are migrated in focused slices with build coverage.
 - Webpack remains a bundler detail, not the source of UI contracts.
 
+### Local Runtime
+
+The Opus runtime must have a supported local Compose mode so the application
+surface can be verified against its service dependencies before release.
+
+Acceptance criteria:
+
+- `BF_MODE=opus` resolves an Opus-specific Compose overlay.
+- The web runtime uses the existing Nginx and PHP service pattern.
+- Opus database configuration resolves to the local MySQL service through the
+  established `MYSQL_DB_*` environment contract.
+- Startup is reported successful only after a published application endpoint is
+  reachable.
+
 ## Known Gaps
 
 - Hoom currently emits Composer optimized-autoload warnings for many classes

--- a/docker/compose.opus.yml
+++ b/docker/compose.opus.yml
@@ -1,0 +1,30 @@
+services:
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "${BF_HTTP_PORT:-8080}:80"
+    volumes:
+      - ./:/app
+      - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - php
+    networks: [bf]
+
+  php:
+    build:
+      context: .
+      dockerfile: docker/php/Dockerfile
+      args:
+        INSTALL_XDEBUG: ${BF_INSTALL_XDEBUG:-false}
+    volumes:
+      - ./:/app
+      - ./docker/php/conf.d/xdebug.ini:/usr/local/etc/php/conf.d/99-xdebug.ini:ro
+    environment:
+      APP_ENV: local
+      PHP_IDE_CONFIG: "serverName=bf-local"
+      MYSQL_DB_HOST: ${BF_MYSQL_DB_HOST:-mysql}
+      MYSQL_DB_PORT: ${BF_MYSQL_DB_PORT:-3306}
+      MYSQL_DB_NAME: ${BF_MYSQL_DB_NAME:-app}
+      MYSQL_DB_USERNAME: ${BF_MYSQL_DB_USERNAME:-root}
+      MYSQL_DB_PASSWORD: ${BF_MYSQL_DB_PASSWORD:-root}
+    networks: [bf]

--- a/harness.json
+++ b/harness.json
@@ -1,0 +1,47 @@
+{
+  "version": "1.0",
+  "defaults": {
+    "laravel": { "mode": "laravel", "services": ["mysql", "redis"], "http_port": 8080 },
+    "opus":    { "mode": "opus",    "services": ["mysql", "redis"], "http_port": 8080 },
+    "frontend": { "mode": "frontend", "services": [],               "http_port": null },
+    "lib":     { "mode": "lib",     "services": [],                 "http_port": null },
+    "php-web": { "mode": "php-web", "services": ["mysql", "redis"], "http_port": 8080 },
+    "php-lib": { "mode": "php-lib", "services": [],                 "http_port": null }
+  },
+  "ports": {
+    "mysql": 33060,
+    "redis": 63790,
+    "memcached": 11211,
+    "mongo": 27018,
+    "postgres": 54320,
+    "elastic": 9200
+  },
+  "docker_env": {
+    "laravel": {
+      "DB_CONNECTION": "mysql",
+      "DB_HOST": "mysql",
+      "DB_PORT": "3306",
+      "DB_DATABASE": "app",
+      "DB_USERNAME": "root",
+      "DB_PASSWORD": "root"
+    },
+    "opus": {
+      "MYSQL_DB_HOST": "mysql",
+      "MYSQL_DB_PORT": "3306",
+      "MYSQL_DB_NAME": "app",
+      "MYSQL_DB_USERNAME": "root",
+      "MYSQL_DB_PASSWORD": "root"
+    },
+    "frontend": { },
+    "lib": { },
+    "php-web": {
+      "DB_CONNECTION": "mysql",
+      "DB_HOST": "mysql",
+      "DB_PORT": "3306",
+      "DB_DATABASE": "app",
+      "DB_USERNAME": "root",
+      "DB_PASSWORD": "root"
+    },
+    "php-lib": { }
+  }
+}

--- a/tests/Unit/Infrastructure/OpusComposeConfigurationTest.php
+++ b/tests/Unit/Infrastructure/OpusComposeConfigurationTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Infrastructure;
+
+use PHPUnit\Framework\TestCase;
+
+final class OpusComposeConfigurationTest extends TestCase
+{
+    public function testOpusModeHasAComposeOverlayForTheWebRuntime(): void
+    {
+        $composePath = $this->projectRoot() . DIRECTORY_SEPARATOR . 'docker' . DIRECTORY_SEPARATOR . 'compose.opus.yml';
+
+        $this->assertFileExists($composePath);
+
+        $compose = (string)file_get_contents($composePath);
+        $this->assertMatchesRegularExpression('/^services:/m', $compose);
+        $this->assertMatchesRegularExpression('/^  nginx:/m', $compose);
+        $this->assertMatchesRegularExpression('/^  php:/m', $compose);
+        $this->assertStringContainsString('MYSQL_DB_HOST: ${BF_MYSQL_DB_HOST:-mysql}', $compose);
+    }
+
+    public function testOpusHarnessDefaultsMatchTheLocalMysqlService(): void
+    {
+        $harness = json_decode(
+            (string)file_get_contents($this->projectRoot() . DIRECTORY_SEPARATOR . 'harness.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+
+        $this->assertSame('opus', $harness['defaults']['opus']['mode']);
+        $this->assertSame('mysql', $harness['docker_env']['opus']['MYSQL_DB_HOST']);
+        $this->assertSame('3306', $harness['docker_env']['opus']['MYSQL_DB_PORT']);
+        $this->assertSame('app', $harness['docker_env']['opus']['MYSQL_DB_NAME']);
+        $this->assertSame('root', $harness['docker_env']['opus']['MYSQL_DB_USERNAME']);
+        $this->assertSame('root', $harness['docker_env']['opus']['MYSQL_DB_PASSWORD']);
+    }
+
+    private function projectRoot(): string
+    {
+        return dirname(__DIR__, 3);
+    }
+}


### PR DESCRIPTION
## Intent

Resolve the remaining locked JWT advisory by consuming the merged Hoom authentication contract and a supported Firebase JWT 7 release.

## User Stories / Acceptance Criteria

- Authentication consumers install a JWT release not affected by GHSA-2x45-7fc3-mxwq.
- Hoom retains RSA token signing, verification, expiry rejection, tamper rejection, and JWK publication behavior.
- The HTTP dependency graph remains on the reviewed Guzzle 7 line.
- The locked production graph has no known Composer advisories.

## Key Changes

- Refresh `bluefission/opus-addon-hoom` to `98db9a8`, which requires `firebase/php-jwt ^7.0`.
- Upgrade `firebase/php-jwt` from `v6.11.1` to `v7.1.0`.
- Retain `guzzlehttp/guzzle v7.15.2` while accepting compatible patch updates to Promises and phpseclib.

## How To Test

```text
composer install --no-interaction --prefer-dist
composer validate --no-check-publish
composer check-platform-reqs
composer audit --locked --no-interaction
vendor/bin/phpunit --do-not-cache-result --bootstrap vendor/autoload.php addons/hoom/tests/Unit/Business/Managers/CryptographyManagerTest.php
vendor/bin/phpunit --do-not-cache-result
```

## Validation

- Hoom JWT integration: 4 tests, 14 assertions.
- Full Opus suite: 116 tests, 609 assertions, 3 expected skips.
- Composer audit: no known security advisories.
- Composer validation and platform requirements pass.
- The existing non-failing Windows link diagnostic remains unchanged.

## QA Checklist

- [x] JWT resolves to `v7.1.0`.
- [x] Hoom declares the supported `^7.0` contract.
- [x] RSA sign/verify and JWK behavior pass against the root-installed graph.
- [x] Expired and tampered tokens are rejected.
- [x] Guzzle remains on `v7.15.2`.
- [x] Locked audit is clean.

## Approval Conditions

- CI passes on supported PHP versions.
- Review confirms the lock refresh contains no unrelated major-version changes.

Closes #41.
