### PR TITLE
Preserve injected environment values during bootstrap

### DIFF
--- a/app/Business/Services/EnvironmentLoader.php
+++ b/app/Business/Services/EnvironmentLoader.php
@@ -4,18 +4,34 @@ declare(strict_types=1);
 
 namespace App\Business\Services;
 
+use BlueFission\Arr;
+use BlueFission\Data\FileSystem;
 use BlueFission\Str;
 
 final class EnvironmentLoader
 {
-    public static function import(string $file): void
+    private static ?Arr $report = null;
+
+    public static function import(string $file): Arr
     {
-        $variables = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        if ($variables === false) {
-            return;
+        $report = Arr::make([
+            'source' => FileSystem::fileBasename($file),
+            'loaded' => 0,
+            'preserved' => 0,
+            'ignored' => 0,
+            'missing' => false,
+            'sources' => [],
+        ]);
+        $contents = FileSystem::fileContents($file);
+        if ($contents === null) {
+            $report->set('missing', true);
+            self::$report = $report;
+
+            return $report;
         }
 
-        foreach ($variables as $variable) {
+        $sources = Arr::make([]);
+        foreach (Str::make($contents)->splitBy('/\R/u') as $variable) {
             $variable = Str::make($variable)->trim();
             if ($variable->isEmpty() || $variable->startsWith('#')) {
                 continue;
@@ -27,13 +43,41 @@ final class EnvironmentLoader
             }
 
             $name = Str::make((string) $parts->shift())->trim();
-            if ($name->isEmpty()) {
+            if ($name->isEmpty() || !$name->matches('/^[A-Za-z_][A-Za-z0-9_]*$/')) {
+                $report->set('ignored', $report->get('ignored') + 1);
                 continue;
             }
 
+            $key = $name->val();
             $value = $parts->join('=')->trim()->val();
-            putenv($name->val() . '=' . $value);
-            $_ENV[$name->val()] = $value;
+            $existing = getenv($key);
+            if ($existing !== false && $existing !== '') {
+                self::synchronize($key, $existing);
+                $sources->set($key, 'process');
+                $report->set('preserved', $report->get('preserved') + 1);
+                continue;
+            }
+
+            self::synchronize($key, $value);
+            $sources->set($key, 'dotenv');
+            $report->set('loaded', $report->get('loaded') + 1);
         }
+
+        $report->set('sources', $sources->val());
+        self::$report = $report;
+
+        return $report;
+    }
+
+    public static function report(): Arr
+    {
+        return Arr::make(self::$report?->val() ?? []);
+    }
+
+    private static function synchronize(string $name, string $value): void
+    {
+        putenv($name . '=' . $value);
+        $_ENV[$name] = $value;
+        $_SERVER[$name] = $value;
     }
 }

--- a/common/helpers/functions.php
+++ b/common/helpers/functions.php
@@ -2,7 +2,7 @@
 
 if(!function_exists('import_env_vars')) {
 	function import_env_vars( $file ) {
-		\App\Business\Services\EnvironmentLoader::import($file);
+		return \App\Business\Services\EnvironmentLoader::import($file);
 	}
 }
 

--- a/tests.md
+++ b/tests.md
@@ -29,6 +29,25 @@ release aliases in the consumer template. All other discovered
 `bluefission/*` packages must have canonical GitHub VCS routes in both the Opus
 root and the consumer template.
 
+## Environment Bootstrap
+
+Process environment values take precedence over entries in the root `.env`
+file. An absent or empty process value may be populated from `.env`. Web, CLI,
+and worker entrypoints load this policy through the shared application settings
+bootstrap.
+
+`EnvironmentLoader::import()` returns an `Arr` report containing counts and a
+per-key `process` or `dotenv` source. The report intentionally excludes all
+configuration values so it can be used in startup diagnostics without exposing
+secrets.
+
+Run the focused environment and entrypoint coverage with:
+
+```powershell
+vendor\bin\phpunit --do-not-cache-result tests\Unit\Business\Services\EnvironmentLoaderTest.php
+vendor\bin\phpunit --do-not-cache-result tests\Unit\TerminalBootstrapOrderTest.php
+```
+
 ## Runtime Contract Validation
 
 The default PHPUnit suite checks that the runtime contract files are present and

--- a/tests/Unit/Business/Services/EnvironmentLoaderTest.php
+++ b/tests/Unit/Business/Services/EnvironmentLoaderTest.php
@@ -5,23 +5,61 @@ declare(strict_types=1);
 namespace Tests\Unit\Business\Services;
 
 use App\Business\Services\EnvironmentLoader;
+use BlueFission\Arr;
+use BlueFission\Data\FileSystem;
+use BlueFission\Str;
 use PHPUnit\Framework\TestCase;
 
 class EnvironmentLoaderTest extends TestCase
 {
+    private const KEYS = [
+        'OPUS_TEST_FIRST',
+        'OPUS_TEST_SECOND',
+        'OPUS_TEST_EMPTY',
+        'OPUS_TEST_REPEAT',
+        'DB_HOST',
+        'DB_DATABASE',
+    ];
+
     private string $file;
+    private array $originalEnvironment = [];
 
     protected function setUp(): void
     {
         $this->file = tempnam(sys_get_temp_dir(), 'opus-env-');
+        foreach (self::KEYS as $key) {
+            $this->originalEnvironment[$key] = [
+                'process' => getenv($key),
+                'env_exists' => array_key_exists($key, $_ENV),
+                'env' => $_ENV[$key] ?? null,
+                'server_exists' => array_key_exists($key, $_SERVER),
+                'server' => $_SERVER[$key] ?? null,
+            ];
+        }
     }
 
     protected function tearDown(): void
     {
-        @unlink($this->file);
-        putenv('OPUS_TEST_FIRST');
-        putenv('OPUS_TEST_SECOND');
-        unset($_ENV['OPUS_TEST_FIRST'], $_ENV['OPUS_TEST_SECOND']);
+        if (FileSystem::fileExists($this->file)) {
+            unlink($this->file);
+        }
+        foreach (self::KEYS as $key) {
+            $original = Arr::make($this->originalEnvironment[$key]);
+            $process = $original->get('process');
+            putenv($process === false ? $key : $key . '=' . $process);
+
+            if ($original->get('env_exists')) {
+                $_ENV[$key] = $original->get('env');
+            } else {
+                unset($_ENV[$key]);
+            }
+
+            if ($original->get('server_exists')) {
+                $_SERVER[$key] = $original->get('server');
+            } else {
+                unset($_SERVER[$key]);
+            }
+        }
     }
 
     public function testItImportsMixedLineEndingsAndValuesContainingEquals(): void
@@ -31,11 +69,81 @@ class EnvironmentLoaderTest extends TestCase
             "OPUS_TEST_FIRST=alpha\r\nOPUS_TEST_SECOND=beta=gamma\n# ignored\r\n"
         );
 
-        EnvironmentLoader::import($this->file);
+        $report = EnvironmentLoader::import($this->file);
 
         $this->assertSame('alpha', getenv('OPUS_TEST_FIRST'));
         $this->assertSame('alpha', $_ENV['OPUS_TEST_FIRST']);
+        $this->assertSame('alpha', $_SERVER['OPUS_TEST_FIRST']);
         $this->assertSame('beta=gamma', getenv('OPUS_TEST_SECOND'));
         $this->assertSame('beta=gamma', $_ENV['OPUS_TEST_SECOND']);
+        $this->assertSame(2, $report->get('loaded'));
+        $this->assertSame(0, $report->get('preserved'));
+        $this->assertSame([
+            'OPUS_TEST_FIRST' => 'dotenv',
+            'OPUS_TEST_SECOND' => 'dotenv',
+        ], $report->get('sources'));
+    }
+
+    public function testItPreservesInjectedDatabaseSettingsAndUsesDotenvFallbacks(): void
+    {
+        file_put_contents($this->file, "DB_HOST=dotenv-host\nDB_DATABASE=dotenv-db\n");
+        putenv('DB_HOST=process-host');
+        putenv('DB_DATABASE');
+        unset($_ENV['DB_HOST'], $_SERVER['DB_HOST'], $_ENV['DB_DATABASE'], $_SERVER['DB_DATABASE']);
+
+        $report = EnvironmentLoader::import($this->file);
+
+        $this->assertSame('process-host', getenv('DB_HOST'));
+        $this->assertSame('process-host', $_ENV['DB_HOST']);
+        $this->assertSame('process-host', $_SERVER['DB_HOST']);
+        $this->assertSame('dotenv-db', getenv('DB_DATABASE'));
+        $this->assertSame(1, $report->get('loaded'));
+        $this->assertSame(1, $report->get('preserved'));
+        $sources = Arr::make($report->get('sources'));
+        $this->assertSame('process', $sources->get('DB_HOST'));
+        $this->assertSame('dotenv', $sources->get('DB_DATABASE'));
+        $this->assertFalse(Str::make($report->toJson())->contains('process-host'));
+        $this->assertFalse(Str::make($report->toJson())->contains('dotenv-db'));
+    }
+
+    public function testItUsesDotenvWhenTheProcessValueIsEmpty(): void
+    {
+        file_put_contents($this->file, "OPUS_TEST_EMPTY=fallback\n");
+        putenv('OPUS_TEST_EMPTY=');
+        $_ENV['OPUS_TEST_EMPTY'] = '';
+        $_SERVER['OPUS_TEST_EMPTY'] = '';
+
+        $report = EnvironmentLoader::import($this->file);
+
+        $this->assertSame('fallback', getenv('OPUS_TEST_EMPTY'));
+        $this->assertSame('fallback', $_ENV['OPUS_TEST_EMPTY']);
+        $this->assertSame('fallback', $_SERVER['OPUS_TEST_EMPTY']);
+        $this->assertSame('dotenv', Arr::make($report->get('sources'))->get('OPUS_TEST_EMPTY'));
+    }
+
+    public function testRepeatedBootstrapDoesNotReplaceTheFirstResolvedValue(): void
+    {
+        file_put_contents($this->file, "OPUS_TEST_REPEAT=first\n");
+        EnvironmentLoader::import($this->file);
+        file_put_contents($this->file, "OPUS_TEST_REPEAT=second\n");
+
+        $report = EnvironmentLoader::import($this->file);
+
+        $this->assertSame('first', getenv('OPUS_TEST_REPEAT'));
+        $this->assertSame(0, $report->get('loaded'));
+        $this->assertSame(1, $report->get('preserved'));
+        $this->assertSame('process', Arr::make($report->get('sources'))->get('OPUS_TEST_REPEAT'));
+    }
+
+    public function testItReportsUnreadableSourcesWithoutWarningsOrValues(): void
+    {
+        unlink($this->file);
+
+        $report = EnvironmentLoader::import($this->file);
+
+        $this->assertTrue($report->get('missing'));
+        $this->assertSame(0, $report->get('loaded'));
+        $this->assertSame([], $report->get('sources'));
+        $this->assertSame($report->val(), EnvironmentLoader::report()->val());
     }
 }

--- a/tests/Unit/TerminalBootstrapOrderTest.php
+++ b/tests/Unit/TerminalBootstrapOrderTest.php
@@ -22,15 +22,18 @@ class TerminalBootstrapOrderTest extends TestCase
         $this->assertLessThan($settings, $autoload);
     }
 
-    public function testWebSocketWorkerLoadsSharedSettingsAfterComposer(): void
+    public function testWebSocketWorkerLoadsSharedSettingsAndRestoresUnlimitedExecution(): void
     {
         $worker = FileSystem::fileContents(dirname(__DIR__, 2) . '/websocket-server.php');
         $this->assertIsString($worker);
         $autoload = Str::pos($worker, "require 'vendor/autoload.php';");
         $settings = Str::pos($worker, "require 'common/helpers/settings.php';");
+        $unlimited = Str::pos($worker, 'set_time_limit(0);');
 
         $this->assertNotFalse($autoload);
         $this->assertNotFalse($settings);
+        $this->assertNotFalse($unlimited);
         $this->assertLessThan($settings, $autoload);
+        $this->assertLessThan($unlimited, $settings);
     }
 }

--- a/tests/Unit/TerminalBootstrapOrderTest.php
+++ b/tests/Unit/TerminalBootstrapOrderTest.php
@@ -21,4 +21,16 @@ class TerminalBootstrapOrderTest extends TestCase
         $this->assertNotFalse($settings);
         $this->assertLessThan($settings, $autoload);
     }
+
+    public function testWebSocketWorkerLoadsSharedSettingsAfterComposer(): void
+    {
+        $worker = FileSystem::fileContents(dirname(__DIR__, 2) . '/websocket-server.php');
+        $this->assertIsString($worker);
+        $autoload = Str::pos($worker, "require 'vendor/autoload.php';");
+        $settings = Str::pos($worker, "require 'common/helpers/settings.php';");
+
+        $this->assertNotFalse($autoload);
+        $this->assertNotFalse($settings);
+        $this->assertLessThan($settings, $autoload);
+    }
 }

--- a/websocket-server.php
+++ b/websocket-server.php
@@ -1,5 +1,7 @@
 <?php
 require 'vendor/autoload.php';
+require 'common/helpers/functions.php';
+require 'common/helpers/settings.php';
 
 use Ratchet\Server\IoServer;
 use Ratchet\Http\HttpServer;

--- a/websocket-server.php
+++ b/websocket-server.php
@@ -2,6 +2,7 @@
 require 'vendor/autoload.php';
 require 'common/helpers/functions.php';
 require 'common/helpers/settings.php';
+set_time_limit(0);
 
 use Ratchet\Server\IoServer;
 use Ratchet\Http\HttpServer;


### PR DESCRIPTION
## Intent

Preserve nonempty deployment environment values while allowing dotenv configuration to provide deterministic fallback values across every Opus runtime entrypoint.

## User stories and acceptance criteria

- Existing nonempty process values remain authoritative.
- Missing or empty process values are populated from dotenv.
- Web, CLI, and WebSocket worker entrypoints share the same settings bootstrap.
- Repeated bootstrap does not replace an already resolved value.
- Import diagnostics identify each key as `process` or `dotenv` without retaining configuration values.

## Key files changed

- `app/Business/Services/EnvironmentLoader.php`: precedence, environment synchronization, and source-only reports.
- `websocket-server.php`: shared settings bootstrap for the worker entrypoint.
- `tests/Unit/Business/Services/EnvironmentLoaderTest.php`: database, fallback, empty, repeated, and diagnostics coverage.
- `tests/Unit/TerminalBootstrapOrderTest.php`: CLI and worker bootstrap order.
- `tests.md`: public behavior and validation guidance.

## How to test

```powershell
vendor\bin\phpunit --do-not-cache-result tests\Unit\Business\Services\EnvironmentLoaderTest.php
vendor\bin\phpunit --do-not-cache-result tests\Unit\TerminalBootstrapOrderTest.php
vendor\bin\phpunit --do-not-cache-result tests\Unit\DevElationHelperUsageTest.php
vendor\bin\phpunit --do-not-cache-result
composer check-platform-reqs --no-interaction
composer audit --locked --no-interaction
```

Focused proof: 8 tests, 39 assertions. Full proof: 121 tests, 639 assertions, with three expected optional skips. The locked dependency audit reports no known advisories.

## QA checklist

- [x] Process-injected database settings remain unchanged.
- [x] Dotenv fallback and empty-value behavior are covered.
- [x] Diagnostic reports contain source names but no values.
- [x] CLI and worker autoload/settings order is verified.
- [x] Full test suite and platform checks pass.
- [x] Diff and PHP syntax checks pass.

## Approval conditions

- Confirm that treating an empty process value as unset matches deployment policy.
- Confirm the source-only report is sufficient for startup diagnostics.
- Existing repository-wide Windows link cleanup and non-SPDX license metadata remain outside this change.

Closes #38
