### PR TITLE
Enforce contextual Vibe value policies

### DIFF
--- a/ADDONS.md
+++ b/ADDONS.md
@@ -106,6 +106,21 @@ Server-rendered templates use `.vibe`, canonical `{$value}` variables,
 executable `.vibe` includes, and named regions. Client-side Reactor bindings
 remain separate from the server template contract.
 
+Values used outside ordinary text or attribute contexts must carry an explicit
+host policy. Use `VibeValue::url()` for links, form actions, and media sources;
+`VibeValue::script()` for JSON literals embedded in scripts; and
+`VibeValue::trustedMarkup()` only for markup composed by a trusted renderer.
+Untrusted strings remain recursively HTML-encoded by default. URL values allow
+relative targets plus `http`, `https`, `mailto`, and `tel`; other schemes,
+protocol-relative targets, and control characters are rejected. Keep template
+execution configured with `run_backend=false`. These host policies can delegate
+to equivalent parser contexts when Vibe exposes them without changing add-on
+call sites.
+
+The renderer retains its positional trusted-variable list for compatibility,
+but it accepts strings only. New code should use the narrowly named
+`VibeValue::trustedMarkup()` boundary instead.
+
 Existing add-ons that map `AddOns\\<PackageName>\\` to the package root should
 migrate the mapping to `logic/` while correcting file namespaces. Run
 `composer dump-autoload -o` and the Opus validator before publishing that

--- a/app/Business/Http/AdminController.php
+++ b/app/Business/Http/AdminController.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Business\Http;
 
+use App\Business\Presentation\VibeValue;
 use BlueFission\Services\Service;
 use BlueFission\BlueCore\Auth as Authenticator;
 
@@ -24,12 +25,12 @@ class AdminController extends Service {
                 'default.vibe',
                 [
                     'csrfToken' => store('_token'),
-                    'sideNav' => $sideNav,
+                    'sideNav' => VibeValue::trustedMarkup($sideNav),
                     'appName' => env('APP_NAME'),
                     'title' => env('APP_NAME') . " Admin",
-                    'url' => '/admin',
+                    'url' => VibeValue::url('/admin'),
                 ],
-                ['sideNav'],
+                [],
                 ['csrfToken', 'sideNav', 'appName', 'title', 'url']
             );
         } else {
@@ -39,7 +40,7 @@ class AdminController extends Service {
                 [
                     'csrfToken' => store('_token'),
                     'appName' => env('APP_NAME'),
-                    'url' => '/admin',
+                    'url' => VibeValue::url('/admin'),
                 ]
             );
         }

--- a/app/Business/Http/LoginController.php
+++ b/app/Business/Http/LoginController.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Business\Http;
 
+use App\Business\Presentation\VibeValue;
 use BlueFission\Services\Service;
 class LoginController extends Service {
 
@@ -11,7 +12,7 @@ class LoginController extends Service {
 
     public function login( )
     {
-        return template('default', 'login.vibe', ['url' => '/login']);
+        return template('default', 'login.vibe', ['url' => VibeValue::url('/login')]);
     }
 
     public function registration( )

--- a/app/Business/Presentation/VibeMenu.php
+++ b/app/Business/Presentation/VibeMenu.php
@@ -70,9 +70,9 @@ final class VibeMenu extends Menu
             [
                 'id' => $this->_id,
                 'label' => $this->_label,
-                'children' => Str::concat('', ...$children),
+                'children' => VibeValue::trustedMarkup(Str::concat('', ...$children)),
             ],
-            ['children'],
+            [],
             ['id', 'label', 'children']
         );
     }

--- a/app/Business/Presentation/VibeMenuItem.php
+++ b/app/Business/Presentation/VibeMenuItem.php
@@ -50,7 +50,7 @@ final class VibeMenuItem extends MenuItem
         return $renderer->render($this->themeName, $this->vibeTemplate, [
             'id' => $this->_id,
             'label' => $this->_label,
-            'action' => $this->_action,
+            'action' => VibeValue::url((string) $this->_action),
         ], [], ['id', 'label', 'action']);
     }
 }

--- a/app/Business/Presentation/VibeValue.php
+++ b/app/Business/Presentation/VibeValue.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Business\Presentation;
+
+final class VibeValue
+{
+    public const URL = 'url';
+
+    public const SCRIPT = 'script';
+
+    public const TRUSTED_MARKUP = 'trusted_markup';
+
+    private function __construct(
+        private readonly string $context,
+        private readonly mixed $value
+    ) {
+    }
+
+    public static function url(string $value): self
+    {
+        return new self(self::URL, $value);
+    }
+
+    public static function script(mixed $value): self
+    {
+        return new self(self::SCRIPT, $value);
+    }
+
+    public static function trustedMarkup(string $value): self
+    {
+        return new self(self::TRUSTED_MARKUP, $value);
+    }
+
+    public function context(): string
+    {
+        return $this->context;
+    }
+
+    public function value(): mixed
+    {
+        return $this->value;
+    }
+}

--- a/app/Business/Services/VibeContextPolicy.php
+++ b/app/Business/Services/VibeContextPolicy.php
@@ -60,7 +60,10 @@ final class VibeContextPolicy
         $url = Str::make($value)->trim();
         $rawUrl = $url->val();
 
-        if (preg_match('/[\x00-\x20\x7F]/', $rawUrl) === 1 || Str::startsWith($rawUrl, '//')) {
+        if (
+            preg_match('/[\x00-\x20\x7F]/', $rawUrl) === 1
+            || preg_match('~^[\\\\/]{2}~', $rawUrl) === 1
+        ) {
             throw new \InvalidArgumentException('Vibe URL values must not contain controls or protocol-relative targets.');
         }
 
@@ -77,9 +80,7 @@ final class VibeContextPolicy
 
     private function protectScript(mixed $value): string
     {
-        if (is_object($value) || is_resource($value)) {
-            throw new \InvalidArgumentException('Vibe script values must be JSON-compatible scalars or arrays.');
-        }
+        $this->assertScriptValue($value);
 
         $encoded = HTTP::jsonEncode($value);
         if (!Str::is($encoded)) {
@@ -92,6 +93,26 @@ final class VibeContextPolicy
             ->replace('>', '\\u003E')
             ->replace("'", '\\u0027')
             ->val();
+    }
+
+    private function assertScriptValue(mixed $value): void
+    {
+        if (Arr::is($value)) {
+            Arr::make($value)->each(fn (mixed $item): mixed => $this->validateScriptItem($item));
+
+            return;
+        }
+
+        if (is_object($value) || is_resource($value)) {
+            throw new \InvalidArgumentException('Vibe script values must be JSON-compatible scalars or arrays.');
+        }
+    }
+
+    private function validateScriptItem(mixed $value): mixed
+    {
+        $this->assertScriptValue($value);
+
+        return $value;
     }
 
     private function trustedMarkup(mixed $value): string

--- a/app/Business/Services/VibeContextPolicy.php
+++ b/app/Business/Services/VibeContextPolicy.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Business\Services;
+
+use App\Business\Presentation\VibeValue;
+use BlueFission\Arr;
+use BlueFission\Net\HTTP;
+use BlueFission\Str;
+
+final class VibeContextPolicy
+{
+    private Arr $allowedUrlSchemes;
+
+    /** @param list<string> $allowedUrlSchemes */
+    public function __construct(array $allowedUrlSchemes = ['http', 'https', 'mailto', 'tel'])
+    {
+        $this->allowedUrlSchemes = Arr::make($allowedUrlSchemes)->map(
+            static fn (string $scheme): string => Str::lower(Str::trim($scheme))
+        );
+    }
+
+    public function protect(mixed $value): mixed
+    {
+        if ($value instanceof VibeValue) {
+            return match ($value->context()) {
+                VibeValue::URL => $this->protectUrl($value->value()),
+                VibeValue::SCRIPT => $this->protectScript($value->value()),
+                VibeValue::TRUSTED_MARKUP => $this->trustedMarkup($value->value()),
+                default => throw new \InvalidArgumentException('Unknown Vibe value context.'),
+            };
+        }
+
+        if (Arr::is($value)) {
+            return Arr::toArray(Arr::make($value)->map(
+                fn (mixed $item): mixed => $this->protect($item)
+            ), true);
+        }
+
+        if (Str::is($value)) {
+            return $this->escapeHtml((string) Str::make($value));
+        }
+
+        if (is_object($value) || is_resource($value)) {
+            throw new \InvalidArgumentException(
+                'Object and resource template values require an explicit supported Vibe value context.'
+            );
+        }
+
+        return $value;
+    }
+
+    private function protectUrl(mixed $value): string
+    {
+        if (!Str::is($value)) {
+            throw new \InvalidArgumentException('Vibe URL values must be strings.');
+        }
+
+        $url = Str::make($value)->trim();
+        $rawUrl = $url->val();
+
+        if (preg_match('/[\x00-\x20\x7F]/', $rawUrl) === 1 || Str::startsWith($rawUrl, '//')) {
+            throw new \InvalidArgumentException('Vibe URL values must not contain controls or protocol-relative targets.');
+        }
+
+        $scheme = HTTP::urlScheme($rawUrl);
+        if (
+            Str::isNotEmpty($scheme)
+            && !$this->allowedUrlSchemes->contains(Str::lower((string) $scheme))
+        ) {
+            throw new \InvalidArgumentException("Vibe URL scheme '{$scheme}' is not allowed.");
+        }
+
+        return $this->escapeHtml($rawUrl);
+    }
+
+    private function protectScript(mixed $value): string
+    {
+        if (is_object($value) || is_resource($value)) {
+            throw new \InvalidArgumentException('Vibe script values must be JSON-compatible scalars or arrays.');
+        }
+
+        $encoded = HTTP::jsonEncode($value);
+        if (!Str::is($encoded)) {
+            throw new \InvalidArgumentException('Vibe script value could not be encoded.');
+        }
+
+        return Str::make($encoded)
+            ->replace('&', '\\u0026')
+            ->replace('<', '\\u003C')
+            ->replace('>', '\\u003E')
+            ->replace("'", '\\u0027')
+            ->val();
+    }
+
+    private function trustedMarkup(mixed $value): string
+    {
+        if (!Str::is($value)) {
+            throw new \InvalidArgumentException('Trusted Vibe markup must be a string.');
+        }
+
+        return (string) Str::make($value);
+    }
+
+    private function escapeHtml(string $value): string
+    {
+        return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
+    }
+}

--- a/app/Business/Services/VibeThemeRenderer.php
+++ b/app/Business/Services/VibeThemeRenderer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Business\Services;
 
+use App\Business\Presentation\VibeValue;
 use BlueFission\Arr;
 use BlueFission\Str;
 use BlueFission\Val;
@@ -17,7 +18,13 @@ final class VibeThemeRenderer
 
     private \Closure $readerFactory;
 
-    public function __construct(?callable $themeResolver = null, ?callable $readerFactory = null)
+    private VibeContextPolicy $contextPolicy;
+
+    public function __construct(
+        ?callable $themeResolver = null,
+        ?callable $readerFactory = null,
+        ?VibeContextPolicy $contextPolicy = null
+    )
     {
         $this->themeResolver = $themeResolver instanceof \Closure
             ? $themeResolver
@@ -25,6 +32,7 @@ final class VibeThemeRenderer
         $this->readerFactory = $readerFactory instanceof \Closure
             ? $readerFactory
             : \Closure::fromCallable($readerFactory ?? static fn (): Reader => new Reader(null));
+        $this->contextPolicy = $contextPolicy ?? new VibeContextPolicy();
     }
 
     /**
@@ -113,29 +121,17 @@ final class VibeThemeRenderer
 
         return Arr::toArray(Arr::make($variables)->map(
             fn (mixed $value, string|int $name): mixed => $trusted->contains((string) $name)
-                ? $value
-                : $this->escapeValue($value)
+                ? $this->protectLegacyTrustedMarkup($value)
+                : $this->contextPolicy->protect($value)
         ), true);
     }
 
-    private function escapeValue(mixed $value): mixed
+    private function protectLegacyTrustedMarkup(mixed $value): string
     {
-        if (Arr::is($value)) {
-            return Arr::toArray(Arr::make($value)->map(
-                fn (mixed $item): mixed => $this->escapeValue($item)
-            ), true);
+        if (!Str::is($value)) {
+            throw new \InvalidArgumentException('Trusted Vibe markup must be a string.');
         }
 
-        if (Str::is($value)) {
-            return htmlspecialchars((string) Str::make($value), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
-        }
-
-        if (is_object($value) || is_resource($value)) {
-            throw new \InvalidArgumentException(
-                'Object and resource template values must be converted to arrays or marked as trusted.'
-            );
-        }
-
-        return $value;
+        return $this->contextPolicy->protect(VibeValue::trustedMarkup((string) $value));
     }
 }

--- a/mapping/default.php
+++ b/mapping/default.php
@@ -1,4 +1,5 @@
 <?php
+use App\Business\Presentation\VibeValue;
 use BlueFission\Services\Mapping;
 use BlueFission\Net\HTTP;
 
@@ -9,7 +10,8 @@ Mapping::add('/', function() {
 		[
 			'title' => "Welcome",
 			'name' => env('APP_NAME'),
-			'url' => '/',
+			'chatTitle' => VibeValue::script(env('APP_NAME')),
+			'url' => VibeValue::url('/'),
 			'csrfToken' => HTTP::session('_token'),
 		]
 	);

--- a/resource/markup/default/default.vibe
+++ b/resource/markup/default/default.vibe
@@ -34,7 +34,7 @@
     aboutText: 'powered by BotMan',
     introMessage: "Hi! I'm your chatbot assistant.",
     chatServer: '/api/chat',
-    title: '{$name}',
+    title: {$chatTitle},
     mainColor: '#c0c0c0',
     bubbleBackground: '#c0c0c0',
     headerTextColor: '#ffffff',

--- a/tests/Unit/Business/Presentation/VibeMenuTest.php
+++ b/tests/Unit/Business/Presentation/VibeMenuTest.php
@@ -74,4 +74,26 @@ final class VibeMenuTest extends TestCase
         $this->assertStringContainsString('Users', $output);
         $this->assertStringContainsString('Manage users', $output);
     }
+
+    public function testItRejectsUnsafeMenuActions(): void
+    {
+        $themeDirectory = dirname(__DIR__, 4) . DIRECTORY_SEPARATOR . 'resource'
+            . DIRECTORY_SEPARATOR . 'markup' . DIRECTORY_SEPARATOR . 'admin';
+        $renderer = new VibeThemeRenderer(
+            static fn (): object => (object) ['location' => $themeDirectory]
+        );
+        $menu = new VibeMenu(
+            'Users',
+            'admin',
+            'sections/menu-top-item.vibe',
+            'sections/menu-sub-item.vibe',
+            $renderer
+        );
+        $menu->addItem(new VibeMenuItem('Unsafe', 'javascript:alert(1)'));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("scheme 'javascript' is not allowed");
+
+        $menu->render();
+    }
 }

--- a/tests/Unit/Business/Services/TemplateHelperIntegrationTest.php
+++ b/tests/Unit/Business/Services/TemplateHelperIntegrationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Business\Services;
 
+use App\Business\Presentation\VibeValue;
 use App\Business\Services\VibeThemeRenderer;
 use BlueFission\BlueCore\Engine;
 use BlueFission\Services\Application;
@@ -39,7 +40,9 @@ final class TemplateHelperIntegrationTest extends TestCase
         $engine = new Engine();
         $engine->delegate('template', $renderer);
 
-        $output = template('default', 'login.vibe', ['url' => '/login?from=helper']);
+        $output = template('default', 'login.vibe', [
+            'url' => VibeValue::url('/login?from=helper'),
+        ]);
 
         $this->assertStringContainsString('/login?from=helper', $output);
         $this->assertStringNotContainsString('@include(', $output);

--- a/tests/Unit/Business/Services/VibeContextPolicyTest.php
+++ b/tests/Unit/Business/Services/VibeContextPolicyTest.php
@@ -57,6 +57,8 @@ final class VibeContextPolicyTest extends TestCase
             'mixed case javascript' => ['JaVaScRiPt:alert(1)'],
             'data' => ['data:text/html,<script>alert(1)</script>'],
             'protocol relative' => ['//example.com/path'],
+            'backslash protocol relative' => ['\\\\example.com/path'],
+            'mixed slash protocol relative' => ['/\\example.com/path'],
             'control' => ["https://example.com/\nscript"],
         ];
     }
@@ -72,6 +74,40 @@ final class VibeContextPolicyTest extends TestCase
         $this->assertStringContainsString('\\u0027', $protected);
         $this->assertStringContainsString('\\u003C\\/script\\u003E', $protected);
         $this->assertStringNotContainsString('</script>', $protected);
+    }
+
+    public function testItRejectsNestedObjectsBeforeEncodingScriptValues(): void
+    {
+        $value = new class implements \JsonSerializable {
+            public function jsonSerialize(): mixed
+            {
+                throw new \RuntimeException('Renderer must not invoke consumer serialization.');
+            }
+        };
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('JSON-compatible scalars or arrays');
+
+        (new VibeContextPolicy())->protect(VibeValue::script([
+            'payload' => ['nested' => $value],
+        ]));
+    }
+
+    public function testItRejectsNestedResourcesBeforeEncodingScriptValues(): void
+    {
+        $resource = fopen('php://memory', 'rb');
+        $this->assertIsResource($resource);
+
+        try {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('JSON-compatible scalars or arrays');
+
+            (new VibeContextPolicy())->protect(VibeValue::script([
+                'payload' => ['nested' => $resource],
+            ]));
+        } finally {
+            fclose($resource);
+        }
     }
 
     public function testItOnlyPassesExplicitStringMarkupWithoutEncoding(): void

--- a/tests/Unit/Business/Services/VibeContextPolicyTest.php
+++ b/tests/Unit/Business/Services/VibeContextPolicyTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Business\Services;
+
+use App\Business\Presentation\VibeValue;
+use App\Business\Services\VibeContextPolicy;
+use PHPUnit\Framework\TestCase;
+
+final class VibeContextPolicyTest extends TestCase
+{
+    public function testItRecursivelyEscapesUntrustedTextAndAttributes(): void
+    {
+        $protected = (new VibeContextPolicy())->protect([
+            'label' => '<Admin>',
+            'attribute' => 'value" onfocus="alert(1)',
+        ]);
+
+        $this->assertSame('&lt;Admin&gt;', $protected['label']);
+        $this->assertSame('value&quot; onfocus=&quot;alert(1)', $protected['attribute']);
+    }
+
+    /** @dataProvider allowedUrlProvider */
+    public function testItAllowsExplicitSafeUrlValues(string $url, string $expected): void
+    {
+        $protected = (new VibeContextPolicy())->protect(VibeValue::url($url));
+
+        $this->assertSame($expected, $protected);
+    }
+
+    /** @return array<string, array{string, string}> */
+    public static function allowedUrlProvider(): array
+    {
+        return [
+            'relative' => ['/admin/users?a=1&b=2', '/admin/users?a=1&amp;b=2'],
+            'fragment' => ['#features', '#features'],
+            'https' => ['https://example.com/path', 'https://example.com/path'],
+            'mail' => ['mailto:team@example.com', 'mailto:team@example.com'],
+            'phone' => ['tel:+15551234567', 'tel:+15551234567'],
+        ];
+    }
+
+    /** @dataProvider rejectedUrlProvider */
+    public function testItRejectsUnsafeUrlValues(string $url): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        (new VibeContextPolicy())->protect(VibeValue::url($url));
+    }
+
+    /** @return array<string, array{string}> */
+    public static function rejectedUrlProvider(): array
+    {
+        return [
+            'javascript' => ['javascript:alert(1)'],
+            'mixed case javascript' => ['JaVaScRiPt:alert(1)'],
+            'data' => ['data:text/html,<script>alert(1)</script>'],
+            'protocol relative' => ['//example.com/path'],
+            'control' => ["https://example.com/\nscript"],
+        ];
+    }
+
+    public function testItEncodesScriptValuesAsNonExecutableJsonLiterals(): void
+    {
+        $protected = (new VibeContextPolicy())->protect(
+            VibeValue::script("'</script><script>alert(1)</script>")
+        );
+
+        $this->assertStringStartsWith('"', $protected);
+        $this->assertStringEndsWith('"', $protected);
+        $this->assertStringContainsString('\\u0027', $protected);
+        $this->assertStringContainsString('\\u003C\\/script\\u003E', $protected);
+        $this->assertStringNotContainsString('</script>', $protected);
+    }
+
+    public function testItOnlyPassesExplicitStringMarkupWithoutEncoding(): void
+    {
+        $markup = '<nav aria-label="Primary">Safe composition</nav>';
+
+        $this->assertSame(
+            $markup,
+            (new VibeContextPolicy())->protect(VibeValue::trustedMarkup($markup))
+        );
+    }
+}

--- a/tests/Unit/Business/Services/VibeThemeRendererTest.php
+++ b/tests/Unit/Business/Services/VibeThemeRendererTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Business\Services;
 
+use App\Business\Presentation\VibeValue;
 use App\Business\Services\VibeThemeRenderer;
 use BlueFission\Vibrato\Reader;
 use PHPUnit\Framework\TestCase;
@@ -27,7 +28,8 @@ final class VibeThemeRendererTest extends TestCase
         $output = $renderer->render('default', 'default.vibe', [
             'name' => 'Opus <script>alert(1)</script>',
             'title' => 'Build & coordinate',
-            'url' => 'https://example.com/?a=1&b=2',
+            'chatTitle' => VibeValue::script("Opus </script><script>alert('x')</script>"),
+            'url' => VibeValue::url('https://example.com/?a=1&b=2'),
             'csrfToken' => 'token"value',
         ]);
 
@@ -35,6 +37,8 @@ final class VibeThemeRendererTest extends TestCase
         $this->assertStringContainsString('aria-label="Primary"', $output);
         $this->assertStringContainsString('Opus &lt;script&gt;alert(1)&lt;/script&gt;', $output);
         $this->assertStringContainsString('Build &amp; coordinate', $output);
+        $this->assertStringContainsString('\\u003C\\/script\\u003E', $output);
+        $this->assertStringNotContainsString("</script><script>alert('x')</script>", $output);
         $this->assertStringNotContainsString('@template(', $output);
         $this->assertStringNotContainsString('@output(', $output);
         $this->assertSame(false, $reader->runConfig['run_backend'] ?? null);
@@ -52,11 +56,10 @@ final class VibeThemeRendererTest extends TestCase
             [
                 'appName' => 'Opus & Company',
                 'title' => '<Admin>',
-                'url' => '/admin',
+                'url' => VibeValue::url('/admin'),
                 'csrfToken' => 'token',
-                'sideNav' => $navigation,
-            ],
-            ['sideNav']
+                'sideNav' => VibeValue::trustedMarkup($navigation),
+            ]
         );
 
         $this->assertStringContainsString($navigation, $output);
@@ -86,8 +89,8 @@ final class VibeThemeRendererTest extends TestCase
 
         $output = $renderer->render('admin', 'modules/menu.vibe', [
             'menuItems' => [
-                ['label' => 'Users <admin>', 'action' => '/users?a=1&b=2'],
-                ['label' => 'Add-ons', 'action' => '/addons'],
+                ['label' => 'Users <admin>', 'action' => VibeValue::url('/users?a=1&b=2')],
+                ['label' => 'Add-ons', 'action' => VibeValue::url('/addons')],
             ],
         ], [], ['menuItems']);
 
@@ -111,14 +114,40 @@ final class VibeThemeRendererTest extends TestCase
         $renderer = $this->renderer('default');
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('must be converted to arrays or marked as trusted');
+        $this->expectExceptionMessage('require an explicit supported Vibe value context');
 
         $renderer->render('default', 'default.vibe', [
             'name' => (object) ['value' => '<script>alert(1)</script>'],
             'title' => 'Welcome',
-            'url' => '/',
+            'url' => VibeValue::url('/'),
             'csrfToken' => 'token',
         ]);
+    }
+
+    public function testItRejectsUnsafeStructuredNavigationUrls(): void
+    {
+        $renderer = $this->renderer('admin');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("scheme 'javascript' is not allowed");
+
+        $renderer->render('admin', 'modules/menu.vibe', [
+            'menuItems' => [
+                ['label' => 'Unsafe', 'action' => VibeValue::url('javascript:alert(1)')],
+            ],
+        ]);
+    }
+
+    public function testLegacyTrustedVariablesOnlyAcceptMarkupStrings(): void
+    {
+        $renderer = $this->renderer('admin');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Trusted Vibe markup must be a string');
+
+        $renderer->render('admin', 'default.vibe', [
+            'sideNav' => (object) ['html' => '<nav>Unsafe</nav>'],
+        ], ['sideNav']);
     }
 
     private function renderer(string $themeName, ?Reader $reader = null): VibeThemeRenderer


### PR DESCRIPTION
## Intent

Add an explicit host-side contextual value policy for Vibe templates while contextual encoding remains outside the current parser contract.

Closes #48.

## User stories and acceptance criteria

- Untrusted text and attribute values remain recursively HTML-encoded.
- URL-bearing values use an explicit `VibeValue::url()` boundary with an allowlist for relative, HTTP, HTTPS, mail, and telephone targets.
- JavaScript, data, protocol-relative, control-character, and other unapproved URL forms are rejected.
- Script-adjacent values use `VibeValue::script()` and render as JSON literals with HTML-significant characters Unicode-escaped.
- Generated markup crosses only the narrowly named `VibeValue::trustedMarkup()` boundary.
- Menu labels and actions follow the same text and URL policy.
- Render-only templates continue to run with `run_backend=false`.

## Key files

- `app/Business/Presentation/VibeValue.php`
- `app/Business/Services/VibeContextPolicy.php`
- `app/Business/Services/VibeThemeRenderer.php`
- `app/Business/Presentation/VibeMenu.php`
- `app/Business/Presentation/VibeMenuItem.php`
- `resource/markup/default/default.vibe`
- `ADDONS.md`

## Validation

```text
vendor/bin/phpunit --do-not-cache-result tests/Unit/Business/Services/VibeContextPolicyTest.php
vendor/bin/phpunit --do-not-cache-result tests/Unit/Business/Services/VibeThemeRendererTest.php
vendor/bin/phpunit --do-not-cache-result tests/Unit/Business/Presentation/VibeMenuTest.php
vendor/bin/phpunit --do-not-cache-result tests/Unit/Business/Services/TemplateHelperIntegrationTest.php
vendor/bin/phpunit --do-not-cache-result tests/Unit/Business/Services/VibeThemeSourceTest.php
vendor/bin/phpunit --do-not-cache-result
composer validate --strict
composer check-platform-reqs
composer audit --locked
git diff --check
```

Focused proof: 30 tests and 386 assertions. Full proof: 132 tests and 635 assertions with three expected skips. The full Windows run exits successfully after the existing link diagnostic. Composer validation reports only the existing non-SPDX license warning; the locked audit has no known advisories.

## QA checklist

- [x] Quotes and tags are encoded in ordinary values.
- [x] Safe relative and allowlisted absolute URLs render with attribute encoding.
- [x] JavaScript and data URLs are rejected in direct and navigation contexts.
- [x] Script termination sequences cannot close the containing script element.
- [x] Trusted markup accepts strings only and remains opt-in.
- [x] The BlueCore three-argument template helper remains compatible through value descriptors.
- [x] Host policy transition to future parser-owned contexts is documented.

## Approval conditions

- Confirm the default URL-scheme allowlist matches platform policy.
- Confirm `VibeValue` is the intended stable host boundary until Vibe exposes equivalent context metadata.
- Require green analysis and no unresolved review threads at the exact head.
