### PR TITLE
Publish Arkheion capability maturity catalog

### DIFF
--- a/ARKHEION.md
+++ b/ARKHEION.md
@@ -1,0 +1,143 @@
+# Arkheion Capability Catalog
+
+## Purpose
+
+Arkheion capabilities begin as bounded Opus add-ons. A capability becomes an
+independently deployable service only when independent scaling, isolation,
+release cadence, reuse, or commercial demand justifies the operational cost.
+Installation or route availability alone does not establish production
+readiness.
+
+This catalog is an Opus host-level readiness record. Capability semantics stay
+with their owning packages. Opus owns application registration, add-on
+discovery and lifecycle, command exposure, themes and routes, health and
+readiness, integration wiring, and bounded application context.
+
+## Evidence And Maturity
+
+The catalog uses these maturity labels:
+
+- **stable**: released, versioned, contract-tested, operationally proven, and
+  supported for the declared compatibility range;
+- **evolving**: package-owned with meaningful tests and integration proof, but
+  still changing before a stable contract;
+- **experimental**: executable proof exists, but compatibility, lifecycle, or
+  operational behavior remains incomplete;
+- **planned**: an approved capability boundary exists without executable proof;
+- **unknown**: available evidence cannot establish ownership or readiness.
+
+The authoritative source order is a released package, an exact package source
+reference in `composer.lock`, versioned Opus source, and finally an observed
+runtime installation. Runtime files beneath `addons/` are ignored by Git and
+are not release evidence by themselves.
+
+## Current Catalog
+
+Snapshot: Opus `17cc2a1`, 2026-08-22. A lock or capability change must refresh
+this table before release.
+
+| Capability | Current source | Maturity | Source-of-truth and duplicate status | Current disposition |
+| --- | --- | --- | --- | --- |
+| Hoom | `bluefission/opus-addon-hoom` at `98db9a8` | evolving | Composer package is authoritative. Runtime directories named `hoom` and `opus-addon-hoom` represent the same metadata identity; coexistence blocks release readiness until one migration path is selected. | Remain a package-owned add-on. Identity and access semantics stay with Hoom and Presence. |
+| Kapsle | `bluefission/opus-addon-kapsle` at `4e39482` | experimental | Composer package is authoritative. Runtime directories named `kapsle` and `opus-addon-kapsle` represent the same metadata identity; coexistence and unresolved autoload diagnostics block release readiness. | Remain a package-owned add-on. Tenancy protocol semantics stay with Kapsle and Annex. |
+| Aimos | runtime installation only | unknown | No versioned Opus source or declared add-on package establishes a release contract. | Keep application-local until package ownership, tests, and lifecycle proof exist. |
+| BasicContact | runtime installation only | unknown | No versioned Opus source or declared add-on package establishes a release contract. | Keep application-local; do not infer a messaging service contract. |
+| Cogito | runtime installation only | unknown | No versioned Opus source or declared add-on package establishes a release contract. | Keep application-local until provider-neutral agent contracts are package-owned. |
+| ForeUP | runtime installation only | unknown | No versioned Opus source or declared add-on package establishes a release contract. | Keep application-local as an external-system adapter candidate. |
+| Presentations | runtime installation only | unknown | No versioned Opus source or declared add-on package establishes a release contract. | Keep application-local until generation inputs, outputs, and storage policy are explicit. |
+| SageMaker | runtime installation only | unknown | No versioned Opus source or declared add-on package establishes a release contract. | Keep application-local as a provider adapter candidate. |
+| Smart Responder | runtime installation only | unknown | No versioned Opus source or declared add-on package establishes a release contract. | Keep application-local; do not merge its contract with contact intake without a reviewed boundary. |
+| Students | runtime installation only | unknown | No versioned Opus source or declared add-on package establishes a release contract. | Keep application-local as a domain capability. |
+| Synematic add-on | runtime installation only | unknown | The add-on has no versioned Opus source. The direct `bluefission/synematic` dependency does not make the runtime add-on release-ready. | Keep application-local until it exposes a package-owned gateway contract. |
+
+No capability in this snapshot is service-ready. Hoom and Kapsle are the only
+package-owned add-on candidates, and both still use unreleased `dev-main`
+constraints in the Opus root graph.
+
+## Shared Opus Host Contract
+
+Every cataloged capability must use the same host boundary:
+
+- Composer owns package installation and autoloading; `type: opus-addon` owns
+  placement beneath the application `addons/` directory.
+- BlueCore owns discovery records and lifecycle persistence. Opus owns the
+  application commands and readiness results that invoke those contracts.
+- Installation, activation, deactivation, and uninstallation return structured
+  results and remain safe to retry at their documented boundaries.
+- An active add-on registers routes, themes, commands, and other contributions
+  exactly once. Inactive or unavailable add-ons register nothing.
+- Wise is the command processor boundary. Opus consumes typed command requests
+  and results without reimplementing parsing or executing a result twice.
+- Provider-neutral central and specialist agent composition remains an Opus
+  lifecycle concern; Automata owns delegation and Synthetiq owns conversational
+  profiles and bounded context behavior.
+- Vibe and Vibrato own template syntax and execution. Opus owns trusted context
+  policy, template selection, and safe output placement.
+- Annex and Synematic own interoperability contracts. Opus exposes declared
+  capabilities without inventing protocol semantics.
+- Health and liveness prove the host process and required persistence state.
+  Optional providers and specialist capabilities belong in readiness details,
+  not process liveness.
+- Configuration names are documented without secret values. Process-injected
+  values take precedence over dotenv fallback.
+
+## Promotion Gates
+
+### Embedded Add-On To Package-Owned Add-On
+
+- one authoritative repository and package identity;
+- canonical add-on layout, namespace, metadata, and direct dependencies;
+- unit, lifecycle, package-install, optimized-autoload, and security-audit proof;
+- idempotent migrations, generators, hooks, and explicit data-retention policy;
+- versioned Opus and upstream compatibility range;
+- removal or documented migration of duplicate runtime copies.
+
+### Package-Owned Add-On To Service-Ready Module
+
+- transport-neutral inputs, outputs, events, commands, schemas, and reason codes;
+- explicit authentication scopes, tenant/isolation model, data classification,
+  retention, rate limits, retries, timeouts, and failure behavior;
+- versioning, migration, backup, rollback, and decommission contracts;
+- provider-independent degradation behavior and a reference integration flow;
+- health, readiness, logs, metrics, traces, and audit/provenance references.
+
+### Service-Ready Module To Internal Service
+
+- immutable source reference and review-gated promotion;
+- independently deployable, observable, reversible, and costed runtime profile;
+- required environment key names, ports, resource envelope, and ownership;
+- operational proof showing that independent deployment creates measurable
+  scaling, isolation, cadence, or reuse value.
+
+### Internal Service To Externally Supported Service
+
+- reviewed SLA, support, security, privacy, and commercial terms;
+- multiple supported integrations or validated paid demand;
+- compatibility, migration, incident, rollback, and end-of-life policies.
+
+## Current Readiness Packet
+
+The following Opus gates precede service extraction:
+
+- lifecycle acceptance and repeat safety: issues #12, #40, and #43, with PR #53;
+- environment precedence and secret-safe bootstrap: issue #38, with PR #54;
+- Composer-installed host and package parity: issue #50, with PR #55;
+- contextual template policy: issue #48, with PR #58;
+- safe integration definition loading: issue #19, with PR #59;
+- dependency-aware Wise registration and authoritative catalog adoption: issues
+  #39 and #61, with PR #60;
+- reproducible asset ownership: issue #11, with PR #62;
+- credential-free base dependency installation: issue #56;
+- verified initialization, runtime health, and launch profiles: issues #25,
+  #20, and #31.
+
+Promotion remains review-gated. Unknown capability state is not equivalent to
+failure, but it cannot be used as release evidence.
+
+## Catalog Update Checklist
+
+For every catalog change, record the capability id, owner, maturity, exact
+source tag or commit, freshness date, compatibility range, commands or API,
+schemas and errors, security and tenancy policy, persistence and migration
+policy, readiness evidence, deployment profile, approval owner, and next gate.
+Do not promote a row when any required field is inferred rather than verified.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ human operators and agents share the same backend contract.
 
 - [Specification](SPEC.md)
 - [Roadmap](ROADMAP.md)
+- [Arkheion capability catalog](ARKHEION.md)
 - [Testing](tests.md)
 
 ## Core Components

--- a/tests/Unit/ArkheionCatalogTest.php
+++ b/tests/Unit/ArkheionCatalogTest.php
@@ -12,18 +12,18 @@ use PHPUnit\Framework\TestCase;
 
 final class ArkheionCatalogTest extends TestCase
 {
-    private const CAPABILITIES = [
-        'Aimos',
-        'BasicContact',
-        'Cogito',
-        'ForeUP',
-        'Hoom',
-        'Kapsle',
-        'Presentations',
-        'SageMaker',
-        'Smart Responder',
-        'Students',
-        'Synematic add-on',
+    private const CAPABILITY_MATURITY = [
+        'Aimos' => 'unknown',
+        'BasicContact' => 'unknown',
+        'Cogito' => 'unknown',
+        'ForeUP' => 'unknown',
+        'Hoom' => 'evolving',
+        'Kapsle' => 'experimental',
+        'Presentations' => 'unknown',
+        'SageMaker' => 'unknown',
+        'Smart Responder' => 'unknown',
+        'Students' => 'unknown',
+        'Synematic add-on' => 'unknown',
     ];
 
     private const PACKAGE_ROWS = [
@@ -34,13 +34,26 @@ final class ArkheionCatalogTest extends TestCase
     public function testCatalogCoversEveryNamedCapabilityAndMaturityState(): void
     {
         $catalog = Str::make((string) FileSystem::fileContents($this->catalogPath()));
+        $rows = [];
 
-        Arr::make(self::CAPABILITIES)->each(
-            fn (string $capability) => $this->assertTrue(
-                $catalog->contains('| ' . $capability . ' |'),
-                $capability . ' is missing from the Arkheion catalog.'
-            )
-        );
+        $catalog->split("\n")->each(function (string $line) use (&$rows): void {
+            $cells = Str::make($line)->split('|');
+            if ($cells->count() < 4) {
+                return;
+            }
+
+            $capability = Str::make((string) $cells->get(1))->trim()->val();
+            if (!Arr::make(self::CAPABILITY_MATURITY)->hasKey($capability)) {
+                return;
+            }
+
+            $rows[$capability] = Str::make((string) $cells->get(3))->trim()->val();
+        });
+
+        Arr::make(self::CAPABILITY_MATURITY)->each(function (string $state, string $capability) use ($rows): void {
+            $this->assertArrayHasKey($capability, $rows, $capability . ' is missing from the Arkheion catalog.');
+            $this->assertSame($state, $rows[$capability], $capability . ' has an unexpected maturity state.');
+        });
 
         Arr::make(['stable', 'evolving', 'experimental', 'planned', 'unknown'])->each(
             fn (string $state) => $this->assertTrue(

--- a/tests/Unit/ArkheionCatalogTest.php
+++ b/tests/Unit/ArkheionCatalogTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use BlueFission\Arr;
+use BlueFission\Data\FileSystem;
+use BlueFission\Net\HTTP;
+use BlueFission\Str;
+use PHPUnit\Framework\TestCase;
+
+final class ArkheionCatalogTest extends TestCase
+{
+    private const CAPABILITIES = [
+        'Aimos',
+        'BasicContact',
+        'Cogito',
+        'ForeUP',
+        'Hoom',
+        'Kapsle',
+        'Presentations',
+        'SageMaker',
+        'Smart Responder',
+        'Students',
+        'Synematic add-on',
+    ];
+
+    public function testCatalogCoversEveryNamedCapabilityAndMaturityState(): void
+    {
+        $catalog = Str::make((string) FileSystem::fileContents($this->catalogPath()));
+
+        Arr::make(self::CAPABILITIES)->each(
+            fn (string $capability) => $this->assertTrue(
+                $catalog->contains('| ' . $capability . ' |'),
+                $capability . ' is missing from the Arkheion catalog.'
+            )
+        );
+
+        Arr::make(['stable', 'evolving', 'experimental', 'planned', 'unknown'])->each(
+            fn (string $state) => $this->assertTrue(
+                $catalog->contains('**' . $state . '**'),
+                $state . ' is missing from the catalog maturity vocabulary.'
+            )
+        );
+    }
+
+    public function testComposerAddOnSourcesStaySynchronizedWithTheCatalog(): void
+    {
+        $root = dirname(__DIR__, 2);
+        $lock = Arr::make(HTTP::jsonDecode(
+            (string) FileSystem::fileContents($root . '/composer.lock'),
+            true,
+            []
+        ));
+        $packages = Arr::make($lock->get('packages', []));
+        $catalog = Str::make((string) FileSystem::fileContents($this->catalogPath()));
+
+        $addOns = $packages->filter(
+            fn (array $package): bool => Arr::make($package)->get('type') === 'opus-addon'
+        );
+
+        $this->assertSame(2, $addOns->size());
+        $addOns->each(function (array $package) use ($catalog): void {
+            $metadata = Arr::make($package);
+            $source = Arr::make($metadata->get('source', []));
+
+            $this->assertTrue($catalog->contains('`' . $metadata->get('name') . '`'));
+            $this->assertTrue($catalog->contains('`' . Str::sub((string) $source->get('reference'), 0, 7) . '`'));
+        });
+    }
+
+    private function catalogPath(): string
+    {
+        return dirname(__DIR__, 2) . '/ARKHEION.md';
+    }
+}

--- a/tests/Unit/ArkheionCatalogTest.php
+++ b/tests/Unit/ArkheionCatalogTest.php
@@ -43,13 +43,20 @@ final class ArkheionCatalogTest extends TestCase
             }
 
             $capability = Str::make((string) $cells->get(1))->trim()->val();
-            if (!Arr::make(self::CAPABILITY_MATURITY)->hasKey($capability)) {
+            if ($capability === 'Capability' || Str::make($capability)->startsWith('---')) {
                 return;
             }
 
+            $this->assertArrayHasKey(
+                $capability,
+                self::CAPABILITY_MATURITY,
+                $capability . ' is not declared in the catalog snapshot.'
+            );
+            $this->assertArrayNotHasKey($capability, $rows, $capability . ' appears more than once.');
             $rows[$capability] = Str::make((string) $cells->get(3))->trim()->val();
         });
 
+        $this->assertCount(count(self::CAPABILITY_MATURITY), $rows);
         Arr::make(self::CAPABILITY_MATURITY)->each(function (string $state, string $capability) use ($rows): void {
             $this->assertArrayHasKey($capability, $rows, $capability . ' is missing from the Arkheion catalog.');
             $this->assertSame($state, $rows[$capability], $capability . ' has an unexpected maturity state.');

--- a/tests/Unit/ArkheionCatalogTest.php
+++ b/tests/Unit/ArkheionCatalogTest.php
@@ -26,6 +26,11 @@ final class ArkheionCatalogTest extends TestCase
         'Synematic add-on',
     ];
 
+    private const PACKAGE_ROWS = [
+        'bluefission/opus-addon-hoom' => 'Hoom',
+        'bluefission/opus-addon-kapsle' => 'Kapsle',
+    ];
+
     public function testCatalogCoversEveryNamedCapabilityAndMaturityState(): void
     {
         $catalog = Str::make((string) FileSystem::fileContents($this->catalogPath()));
@@ -64,9 +69,24 @@ final class ArkheionCatalogTest extends TestCase
         $addOns->each(function (array $package) use ($catalog): void {
             $metadata = Arr::make($package);
             $source = Arr::make($metadata->get('source', []));
+            $packageName = (string) $metadata->get('name');
+            $reference = Str::sub((string) $source->get('reference'), 0, 7);
 
-            $this->assertTrue($catalog->contains('`' . $metadata->get('name') . '`'));
-            $this->assertTrue($catalog->contains('`' . Str::sub((string) $source->get('reference'), 0, 7) . '`'));
+            $this->assertArrayHasKey($packageName, self::PACKAGE_ROWS);
+
+            $expectedRow = Str::make('| ')
+                ->append(self::PACKAGE_ROWS[$packageName])
+                ->append(' | `')
+                ->append($packageName)
+                ->append('` at `')
+                ->append($reference)
+                ->append('` |')
+                ->val();
+
+            $this->assertTrue(
+                $catalog->contains($expectedRow),
+                $packageName . ' and ' . $reference . ' must appear in the same catalog row.'
+            );
         });
     }
 


### PR DESCRIPTION
## Intent

Publish a source-backed Arkheion capability catalog that distinguishes runtime add-ons, package-owned add-ons, and independently deployable service candidates without implying unsupported maturity.

Closes #63.

## User Stories And Acceptance Criteria

- Maintainers can identify every named capability's current evidence, maturity, ownership, and next disposition.
- Hoom and Kapsle package sources are authoritative, and duplicate runtime identities are explicit release blockers.
- Workspace-only capabilities remain `unknown` until versioned package and lifecycle evidence exists.
- Opus host responsibilities remain separate from identity, tenancy, orchestration, protocol, language, provider, and storage semantics.
- Promotion from embedded add-on through externally supported service is executable and review-gated.
- Current Opus readiness issues and PRs are linked in one packet.

## Key Files

- `ARKHEION.md`: maturity vocabulary, current catalog, host contract, promotion gates, and readiness packet.
- `tests/Unit/ArkheionCatalogTest.php`: named-capability and Composer source synchronization proof.
- `README.md`: catalog navigation.

## How To Test

```text
vendor/bin/phpunit --do-not-cache-result tests/Unit/ArkheionCatalogTest.php
vendor/bin/phpunit --do-not-cache-result
php -l tests/Unit/ArkheionCatalogTest.php
git diff --check
```

Observed results:

- Catalog contract: 2 tests, 21 assertions.
- Full suite: 118 tests, 630 assertions, 3 expected skips.

## QA Checklist

- [x] Every named capability has an explicit maturity label.
- [x] Composer add-on package names and exact refs are test-enforced.
- [x] No capability is represented as service-ready.
- [x] Duplicate Hoom and Kapsle runtime identities are explicit.
- [x] Package and host ownership boundaries remain separate.
- [x] Public documentation contains no credentials or workstation-specific instructions.

## Approval Conditions

- Confirm Hoom should remain `evolving` and Kapsle `experimental` for this snapshot.
- Confirm workspace-only capabilities should remain `unknown` until package evidence exists.
- Refresh the snapshot whenever the Composer add-on refs or named capability inventory changes.
