### PR TITLE
preserve injected environment values during bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ metadata in the lock.
 Opus maintainers can verify that the template still covers the complete locked
 Blue Fission dependency graph with `composer audit:composer-vcs`.
 
+### Environment Precedence
+
+Process-injected, non-empty environment values take precedence over `.env`
+entries. The shared application settings loader uses `.env` only as a fallback
+for absent or empty values and applies the same result to `getenv()`, `$_ENV`,
+and `$_SERVER`. Web, CLI, and worker entrypoints must load Composer before the
+shared settings file so the same policy is used in every runtime.
+
+`EnvironmentLoader::lastReport()` and `EnvironmentLoader::sourceOf()` expose
+key names and their `process` or `dotenv` source for startup diagnostics. They
+never expose configuration values.
+
 ## Usage
 
 ### Event Management

--- a/app/Business/Services/EnvironmentLoader.php
+++ b/app/Business/Services/EnvironmentLoader.php
@@ -4,36 +4,130 @@ declare(strict_types=1);
 
 namespace App\Business\Services;
 
+use BlueFission\Arr;
+use BlueFission\Data\FileSystem;
 use BlueFission\Str;
 
 final class EnvironmentLoader
 {
+    public const SOURCE_DOTENV = 'dotenv';
+    public const SOURCE_PROCESS = 'process';
+
+    private static array $loadedValues = [];
+    private static array $sources = [];
+    private static array $lastReport = [
+        'status' => 'not_loaded',
+        'loaded' => [],
+        'preserved' => [],
+        'ignored' => 0,
+    ];
+
     public static function import(string $file): void
     {
-        $variables = file($file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        if ($variables === false) {
-            return;
+        self::$lastReport = self::load($file);
+    }
+
+    public static function lastReport(): array
+    {
+        return self::$lastReport;
+    }
+
+    public static function sourceOf(string $name): ?string
+    {
+        return self::$sources[$name] ?? null;
+    }
+
+    private static function load(string $file): array
+    {
+        $report = [
+            'status' => 'missing',
+            'loaded' => [],
+            'preserved' => [],
+            'ignored' => 0,
+        ];
+        $contents = FileSystem::fileContents($file);
+        if (!Str::is($contents)) {
+            return $report;
         }
 
-        foreach ($variables as $variable) {
-            $variable = Str::make($variable)->trim();
+        $report['status'] = 'loaded';
+        $variables = Str::make($contents)->split("\n");
+
+        $variables->each(function (string $line) use (&$report): void {
+            $variable = Str::make($line)->trim();
             if ($variable->isEmpty() || $variable->startsWith('#')) {
-                continue;
+                return;
             }
 
             $parts = $variable->split('=');
             if ($parts->count() < 2) {
-                continue;
+                $report['ignored']++;
+                return;
             }
 
             $name = Str::make((string) $parts->shift())->trim();
             if ($name->isEmpty()) {
-                continue;
+                $report['ignored']++;
+                return;
+            }
+
+            $key = $name->val();
+            $existing = self::existingValue($key);
+            if ($existing !== null) {
+                self::write($key, $existing);
+                $source = self::isPreviouslyLoadedValue($key, $existing)
+                    ? self::SOURCE_DOTENV
+                    : self::SOURCE_PROCESS;
+                self::$sources[$key] = $source;
+                if ($source === self::SOURCE_PROCESS) {
+                    unset(self::$loadedValues[$key]);
+                }
+                $report['preserved'][] = ['name' => $key, 'source' => $source];
+                return;
             }
 
             $value = $parts->join('=')->trim()->val();
-            putenv($name->val() . '=' . $value);
-            $_ENV[$name->val()] = $value;
+            self::write($key, $value);
+            self::$loadedValues[$key] = $value;
+            self::$sources[$key] = self::SOURCE_DOTENV;
+            $report['loaded'][] = ['name' => $key, 'source' => self::SOURCE_DOTENV];
+        });
+
+        return $report;
+    }
+
+    private static function existingValue(string $name): ?string
+    {
+        $process = getenv($name);
+        if ($process !== false && $process !== '') {
+            return (string) $process;
         }
+
+        $environment = Arr::make($_ENV);
+        $environmentValue = $environment->get($name);
+        if ($environment->hasKey($name) && Str::is($environmentValue) && $environmentValue !== '') {
+            return $environmentValue;
+        }
+
+        $server = Arr::make($_SERVER);
+        $serverValue = $server->get($name);
+        if ($server->hasKey($name) && Str::is($serverValue) && $serverValue !== '') {
+            return $serverValue;
+        }
+
+        return null;
+    }
+
+    private static function isPreviouslyLoadedValue(string $name, string $value): bool
+    {
+        return Arr::make(self::$loadedValues)->hasKey($name)
+            && self::$loadedValues[$name] === $value;
+    }
+
+    private static function write(string $name, string $value): void
+    {
+        putenv($name . '=' . $value);
+        $_ENV[$name] = $value;
+        $_SERVER[$name] = $value;
     }
 }

--- a/tests/Unit/Business/Services/EnvironmentLoaderTest.php
+++ b/tests/Unit/Business/Services/EnvironmentLoaderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Business\Services;
 
 use App\Business\Services\EnvironmentLoader;
+use BlueFission\Arr;
 use PHPUnit\Framework\TestCase;
 
 class EnvironmentLoaderTest extends TestCase
@@ -19,9 +20,10 @@ class EnvironmentLoaderTest extends TestCase
     protected function tearDown(): void
     {
         @unlink($this->file);
-        putenv('OPUS_TEST_FIRST');
-        putenv('OPUS_TEST_SECOND');
-        unset($_ENV['OPUS_TEST_FIRST'], $_ENV['OPUS_TEST_SECOND']);
+        Arr::make($this->keys())->each(function (string $key): void {
+            putenv($key);
+            unset($_ENV[$key], $_SERVER[$key]);
+        });
     }
 
     public function testItImportsMixedLineEndingsAndValuesContainingEquals(): void
@@ -35,7 +37,76 @@ class EnvironmentLoaderTest extends TestCase
 
         $this->assertSame('alpha', getenv('OPUS_TEST_FIRST'));
         $this->assertSame('alpha', $_ENV['OPUS_TEST_FIRST']);
+        $this->assertSame('alpha', $_SERVER['OPUS_TEST_FIRST']);
         $this->assertSame('beta=gamma', getenv('OPUS_TEST_SECOND'));
         $this->assertSame('beta=gamma', $_ENV['OPUS_TEST_SECOND']);
+        $this->assertSame(EnvironmentLoader::SOURCE_DOTENV, EnvironmentLoader::sourceOf('OPUS_TEST_FIRST'));
+    }
+
+    public function testItPreservesNonEmptyValuesInjectedThroughEveryRuntimeStore(): void
+    {
+        file_put_contents(
+            $this->file,
+            "OPUS_TEST_PROCESS=dotenv\nOPUS_TEST_ENV=dotenv\nOPUS_TEST_SERVER=dotenv\n"
+        );
+        putenv('OPUS_TEST_PROCESS=process-secret');
+        $_ENV['OPUS_TEST_ENV'] = 'environment';
+        $_SERVER['OPUS_TEST_SERVER'] = 'server';
+
+        EnvironmentLoader::import($this->file);
+
+        $this->assertSame('process-secret', getenv('OPUS_TEST_PROCESS'));
+        $this->assertSame('environment', getenv('OPUS_TEST_ENV'));
+        $this->assertSame('server', getenv('OPUS_TEST_SERVER'));
+        $this->assertSame('process-secret', $_ENV['OPUS_TEST_PROCESS']);
+        $this->assertSame('environment', $_SERVER['OPUS_TEST_ENV']);
+        $this->assertSame('server', $_ENV['OPUS_TEST_SERVER']);
+        $this->assertSame(EnvironmentLoader::SOURCE_PROCESS, EnvironmentLoader::sourceOf('OPUS_TEST_PROCESS'));
+
+        $report = Arr::make(EnvironmentLoader::lastReport());
+        $this->assertSame('loaded', $report->get('status'));
+        $this->assertCount(3, $report->get('preserved'));
+        $this->assertStringNotContainsString('process-secret', Arr::make($report->get('preserved'))->toJson());
+    }
+
+    public function testItTreatsEmptyRuntimeValuesAsUnsetFallbacks(): void
+    {
+        file_put_contents($this->file, "OPUS_TEST_EMPTY=fallback\n");
+        putenv('OPUS_TEST_EMPTY=');
+        $_ENV['OPUS_TEST_EMPTY'] = '';
+        $_SERVER['OPUS_TEST_EMPTY'] = '';
+
+        EnvironmentLoader::import($this->file);
+
+        $this->assertSame('fallback', getenv('OPUS_TEST_EMPTY'));
+        $this->assertSame('fallback', $_ENV['OPUS_TEST_EMPTY']);
+        $this->assertSame('fallback', $_SERVER['OPUS_TEST_EMPTY']);
+        $this->assertSame(EnvironmentLoader::SOURCE_DOTENV, EnvironmentLoader::sourceOf('OPUS_TEST_EMPTY'));
+    }
+
+    public function testRepeatedImportsDoNotReplaceAnEstablishedValue(): void
+    {
+        file_put_contents($this->file, "OPUS_TEST_REPEAT=first\n");
+        EnvironmentLoader::import($this->file);
+        file_put_contents($this->file, "OPUS_TEST_REPEAT=second\n");
+
+        EnvironmentLoader::import($this->file);
+
+        $this->assertSame('first', getenv('OPUS_TEST_REPEAT'));
+        $this->assertSame(EnvironmentLoader::SOURCE_DOTENV, EnvironmentLoader::sourceOf('OPUS_TEST_REPEAT'));
+        $this->assertSame([], Arr::make(EnvironmentLoader::lastReport())->get('loaded'));
+    }
+
+    private function keys(): array
+    {
+        return [
+            'OPUS_TEST_FIRST',
+            'OPUS_TEST_SECOND',
+            'OPUS_TEST_PROCESS',
+            'OPUS_TEST_ENV',
+            'OPUS_TEST_SERVER',
+            'OPUS_TEST_EMPTY',
+            'OPUS_TEST_REPEAT',
+        ];
     }
 }


### PR DESCRIPTION
## Intent

Load `.env` as fallback configuration without replacing non-empty values already supplied by the process or PHP runtime.

## User stories and acceptance criteria

- Preserve non-empty values supplied through `getenv()`, `$_ENV`, or `$_SERVER`.
- Populate absent or empty values from `.env` and synchronize the resolved value across PHP runtime stores.
- Keep repeated bootstrap imports idempotent.
- Expose source-only startup diagnostics without exposing configuration values.
- Document one shared post-autoload environment policy for web, CLI, and worker entrypoints.

## Key files

- `app/Business/Services/EnvironmentLoader.php`
- `tests/Unit/Business/Services/EnvironmentLoaderTest.php`
- `README.md`

## Validation

```text
vendor/bin/phpunit --do-not-cache-result tests/Unit/Business/Services/EnvironmentLoaderTest.php
4 tests, 23 assertions

vendor/bin/phpunit --do-not-cache-result
119 tests, 628 assertions, 3 expected skips

composer check-platform-reqs
All requirements satisfied

composer audit
No security vulnerability advisories found
```

`composer validate --strict` reports only the existing non-SPDX `Exclusive` license warning tracked separately.

## QA checklist

- [x] Process, `$_ENV`, and `$_SERVER` precedence covered
- [x] Empty-value fallback covered
- [x] Repeated bootstrap covered
- [x] Diagnostic output excludes values
- [x] Full baseline suite passes

## Approval conditions

- Confirm the fallback semantics and source labels are suitable for startup diagnostics.
- Confirm writing the resolved value to all three PHP runtime stores is the intended consistency contract.

Closes #38
