### PR TITLE
Report truthful add-on lifecycle outcomes

### DIFF
--- a/ADDONS.md
+++ b/ADDONS.md
@@ -135,6 +135,20 @@ The current manager scans each immediate directory under `addons/`. A discoverab
 
 The primary file is required for runtime loading and lifecycle hooks. Active add-ons are loaded from the stored add-on path plus `primary_file`. Installation and uninstallation load that same file and call `<name>_install()` or `<name>_uninstall()` when the corresponding function exists. Declare both hook functions in the global namespace; the current manager performs an unqualified lookup and does not resolve namespaced functions.
 
+Lifecycle commands and administrative endpoints return structured readiness
+outcomes. Single outcomes include `ok`, `action`, `changed`, `stage`,
+`nextAction`, per-step results, and stable readiness reason codes. Batch
+outcomes recompute `total`, `succeeded`, and `failed` from their normalized
+children instead of trusting optimistic aggregate counters.
+
+Structured migration and population failures block install readiness even when
+an underlying manager reports optimistic top-level success. A missing lifecycle
+callable is an optional, skipped hook; missing or unsafe primary files and
+failed declared hooks remain blocking. Human-readable output is diagnostic and
+is never parsed to infer success. Migration, generator, registration, and hook
+implementations must return or throw a structured failure at their ownership
+boundary.
+
 Installation configures datasource migrations from `datasources/structure/` and datasource generators from `datasources/generator/` unconditionally, so both directories must exist. Each structure file must expose a global-namespace class with `change()` and `revert()` methods. Each generator file must expose a global-namespace class with `populate()`. A global-namespace `RootSeeder.php` class may instead provide `seeders()` to select and order the remaining generator classes. The locked loader resolves extracted short class names without their declared namespace. Keep those resources inside the add-on directory and make their work safe to repeat. Activation and deactivation persist add-on state; activation does not replace installation or dependency setup.
 
 The `libraries` list executes root-level Composer require commands during installation and remove commands during uninstallation. Because root requirements are shared by every add-on, removal must be coordinated so one package does not remove a dependency still owned by another.

--- a/app/Business/Console/AddOnManager.php
+++ b/app/Business/Console/AddOnManager.php
@@ -86,7 +86,7 @@ class AddOnManager extends Service
             return null;
         }
 
-        return Str::make((string) $name)->trim()->lower()->val();
+        return Str::make((string) $name)->trim()->val();
     }
 
     private function installedAddOn($behavior, string $action): array

--- a/app/Business/Console/AddOnManager.php
+++ b/app/Business/Console/AddOnManager.php
@@ -101,8 +101,8 @@ class AddOnManager extends Service
         }
 
         $addOn = $this->manager->getAddOnData($name);
-        $id = $addOn?->addon_id ?? null;
-        if ($addOn === null || $id === null) {
+        $id = is_object($addOn) ? ($addOn->addon_id ?? null) : null;
+        if ($id === null) {
             return ['failure' => $this->readiness->failure(
                 $action,
                 'addon_not_found',

--- a/app/Business/Console/AddOnManager.php
+++ b/app/Business/Console/AddOnManager.php
@@ -1,117 +1,115 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Business\Console;
 
+use App\Business\Services\AddOnLifecycleReadinessService;
+use BlueFission\Arr;
 use BlueFission\Services\Service;
+use BlueFission\Str;
 
 class AddOnManager extends Service
 {
-    protected $_addonManager;
+    private object $manager;
+    private AddOnLifecycleReadinessService $readiness;
 
-    public function __construct( )
-    {
-        $addonManager = instance('addons');
-        $this->_addonManager = $addonManager;
+    public function __construct(
+        ?object $manager = null,
+        ?AddOnLifecycleReadinessService $readiness = null
+    ) {
         parent::__construct();
+
+        $this->manager = $manager ?? instance('addons');
+        $this->readiness = $readiness ?? new AddOnLifecycleReadinessService();
     }
 
-    public function install($behavior)
+    public function install($behavior): array
     {
-        $addonName = $behavior?->context['data'] ?? null;
-
-        if (empty($addonName)) {
-            echo "Addon name must be provided.\n";
-            return;
+        $name = $this->addOnName($behavior);
+        if ($name === null) {
+            return $this->readiness->failure('install', 'addon_name_required', 'Add-on name must be provided.');
         }
 
-        $status = $this->_addonManager->install($addonName);
-        echo "Installation completed with status: $status\n";
+        return $this->readiness->normalize($this->manager->install($name));
     }
 
-    public function install_all()
+    public function install_all(): array
     {
-        $status = $this->_addonManager->installAll();
-        echo "Installation of all addons completed with status: $status\n";
+        return $this->readiness->normalize($this->manager->installAll());
     }
 
-    public function uninstall($behavior)
+    public function uninstall($behavior): array
     {
-        $addonName = $behavior?->context['data'] ?? null;
-
-        if (empty($addonName)) {
-            echo "Addon name must be provided.\n";
-            return;
+        $resolved = $this->installedAddOn($behavior, 'uninstall');
+        if (Arr::hasKey($resolved, 'failure')) {
+            return (array) Arr::getPath($resolved, 'failure');
         }
 
-        $addon = $this->_addonManager->getAddOnData($addonName);
-        if (!$addon) {
-            echo "Addon $addonName not found.\n";
-            return;
-        }
-
-        $status = $this->_addonManager->uninstall($addon->addon_id);
-        echo "Uninstallation completed with status: $status\n";
+        return $this->readiness->normalize($this->manager->uninstall(Arr::getPath($resolved, 'id')));
     }
 
-    public function activate($behavior)
+    public function activate($behavior): array
     {
-        $addonName = $behavior?->context['data'] ?? null;
-
-        if (empty($addonName)) {
-            echo "Addon name must be provided.\n";
-            return;
+        $resolved = $this->installedAddOn($behavior, 'activate');
+        if (Arr::hasKey($resolved, 'failure')) {
+            return (array) Arr::getPath($resolved, 'failure');
         }
 
-        $addon = $this->_addonManager->getAddOnData($addonName);
-        if (!$addon) {
-            echo "Addon $addonName not found.\n";
-            return;
-        }
-
-        $status = $this->_addonManager->activate($addon->addon_id);
-        echo "Activation completed with status: $status\n";
+        return $this->readiness->normalize($this->manager->activate(Arr::getPath($resolved, 'id')));
     }
 
-    public function activate_all()
+    public function activate_all(): array
     {
-        $status = $this->_addonManager->activateAll();
-        echo "Activation of all addons completed with status: $status\n";
+        return $this->readiness->normalize($this->manager->activateAll());
     }
 
-    public function deactivate($behavior)
+    public function deactivate($behavior): array
     {
-        $addonName = $behavior?->context['data'] ?? null;
-        
-        if (empty($addonName)) {
-            echo "Addon name must be provided.\n";
-            return;
+        $resolved = $this->installedAddOn($behavior, 'deactivate');
+        if (Arr::hasKey($resolved, 'failure')) {
+            return (array) Arr::getPath($resolved, 'failure');
         }
 
-        $addon = $this->_addonManager->getAddOnData($addonName);
-        if (!$addon) {
-            echo "Addon $addonName not found.\n";
-            return;
-        }
-
-        $status = $this->_addonManager->deactivate($addon->addon_id);
-        echo "Deactivation completed with status: $status\n";
+        return $this->readiness->normalize($this->manager->deactivate(Arr::getPath($resolved, 'id')));
     }
 
-    public function showAll()
+    public function showAll(): array
     {
-        $addons = $this->_addonManager->showAllAddOns();
+        return $this->readiness->listing((array) $this->manager->showAllAddOns());
+    }
 
-        if (empty($addons)) {
-            echo "No addons found.\n";
-            return;
+    private function addOnName($behavior): ?string
+    {
+        $name = Arr::getPath((array) ($behavior?->context ?? []), 'data');
+        if (!Str::is($name) || Str::make((string) $name)->trim()->isEmpty()) {
+            return null;
         }
 
-        echo "Showing all addons:\n";
-        foreach ($addons as $addon) {
-            echo "Addon: {$addon->name}\n";
-            echo "Description: {$addon->description}\n";
-            echo "Path: {$addon->path}\n";
-            echo "-----------------------------------\n";
+        return Str::make((string) $name)->trim()->lower()->val();
+    }
+
+    private function installedAddOn($behavior, string $action): array
+    {
+        $name = $this->addOnName($behavior);
+        if ($name === null) {
+            return ['failure' => $this->readiness->failure(
+                $action,
+                'addon_name_required',
+                'Add-on name must be provided.'
+            )];
         }
+
+        $addOn = $this->manager->getAddOnData($name);
+        $id = $addOn?->addon_id ?? null;
+        if ($addOn === null || $id === null) {
+            return ['failure' => $this->readiness->failure(
+                $action,
+                'addon_not_found',
+                "Add-on {$name} was not found."
+            )];
+        }
+
+        return ['id' => $id];
     }
 }

--- a/app/Business/Http/Api/Admin/AddOnController.php
+++ b/app/Business/Http/Api/Admin/AddOnController.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Business\Http\Api\Admin;
 
+use App\Business\Services\AddOnLifecycleReadinessService;
 use BlueFission\Arr;
 use BlueFission\Services\Service;
 use BlueFission\Services\Request;
@@ -13,6 +14,15 @@ use BlueFission\BlueCore\Domain\AddOn\AddOn;
 use BlueFission\BlueCore\Domain\AddOn\Models\AddOnModel;
 
 class AddOnController extends Service {
+
+    private AddOnLifecycleReadinessService $readiness;
+
+    public function __construct(?AddOnLifecycleReadinessService $readiness = null)
+    {
+        parent::__construct();
+
+        $this->readiness = $readiness ?? new AddOnLifecycleReadinessService();
+    }
 
     public function index( IAllAddOnsQuery $query ) {
         $installedAddons = $query->fetch();
@@ -60,7 +70,7 @@ class AddOnController extends Service {
         $manager = instance('addons');
         $status = $manager->install($request->name);
 
-        return $status;
+        return $this->readiness->normalize($status);
     }
 
     public function uninstall( Request $request )
@@ -68,7 +78,7 @@ class AddOnController extends Service {
         $manager = instance('addons');
         $status = $manager->uninstall($request->addon_id);
 
-        return $status;
+        return $this->readiness->normalize($status);
     }
 
     public function activate( Request $request )
@@ -80,6 +90,6 @@ class AddOnController extends Service {
             $status = $manager->activate($request->addon_id);
         }
 
-        return $status;
+        return $this->readiness->normalize($status);
     }
 }

--- a/app/Business/Services/AddOnLifecycleReadinessService.php
+++ b/app/Business/Services/AddOnLifecycleReadinessService.php
@@ -175,15 +175,7 @@ final class AddOnLifecycleReadinessService extends Service
 
         $stage = (string) ($outcome->get('stage') ?: 'lifecycle');
         $message = (string) $outcome->get('error');
-        $matched = false;
-        $reasons->each(function ($reason) use ($stage, $message, &$matched): void {
-            $matched = $matched
-                || Arr::getPath((array) $reason, 'stage') === $stage
-                || (
-                    Str::isNotEmpty($message)
-                    && Arr::getPath((array) $reason, 'message') === $message
-                );
-        });
+        $matched = $this->hasMatchingReason($reasons, $stage, $message);
 
         return !$matched
             && (Str::isNotEmpty($message) || !Arr::make(['complete', 'hook'])->contains($stage));
@@ -191,6 +183,9 @@ final class AddOnLifecycleReadinessService extends Service
 
     private function normalizeBatch(Arr $outcome, array $results): array
     {
+        $aggregateFailed = Flag::isFalse($outcome->get('ok'));
+        $aggregateStage = (string) ($outcome->get('stage') ?: 'lifecycle');
+        $aggregateError = (string) ($outcome->get('error') ?: 'Add-on lifecycle batch failed.');
         $normalized = Arr::make($results)
             ->map(fn ($result): array => $this->normalizeLifecycle(Arr::make((array) $result)))
             ->values();
@@ -204,17 +199,29 @@ final class AddOnLifecycleReadinessService extends Service
         $failures->each(function (array $result) use ($reasons): void {
             $reasons->mergeRecursive((array) Arr::getPath($result, 'readiness.reasons', []));
         });
+        $recoveredChildFailuresOnly = $this->batchFailureIsRecoveredChildrenOnly($results);
+        $independentAggregateFailure = $aggregateFailed
+            && !$recoveredChildFailuresOnly
+            && !$this->hasMatchingReason($reasons, $aggregateStage, $aggregateError);
+        if ($independentAggregateFailure) {
+            $reasons->unshift($this->reason(
+                'addon_lifecycle_failed',
+                $aggregateStage,
+                $aggregateError
+            ));
+        }
         $total = $normalized->count();
         $failed = $failures->count();
+        $blocked = $failed > 0 || $independentAggregateFailure;
 
-        $outcome->set('ok', $failed === 0);
+        $outcome->set('ok', !$blocked);
         $outcome->set('changed', $changes->count() > 0);
         $outcome->set('total', $total);
         $outcome->set('succeeded', $total - $failed);
         $outcome->set('failed', $failed);
         $outcome->set('results', $normalized->toArray());
-        if ($failed > 0) {
-            $first = Arr::make((array) $reasons->get(0));
+        if ($blocked) {
+            $first = $this->selectedReason($outcome, $reasons);
             $outcome->set('stage', $first->get('stage') ?: 'lifecycle');
             $outcome->set('error', $first->get('message') ?: 'Add-on lifecycle action failed.');
             $outcome->set('nextAction', 'retry_lifecycle');
@@ -226,7 +233,7 @@ final class AddOnLifecycleReadinessService extends Service
             }
         }
         $outcome->set('readiness', [
-            'state' => $failed === 0 ? 'ready' : 'blocked',
+            'state' => $blocked ? 'blocked' : 'ready',
             'reasons' => $reasons->toArray(),
         ]);
 
@@ -241,6 +248,34 @@ final class AddOnLifecycleReadinessService extends Service
         }
 
         return $action === 'install_all' ? 'activate_all' : null;
+    }
+
+    private function hasMatchingReason(Arr $reasons, string $stage, string $message): bool
+    {
+        $matched = false;
+        $reasons->each(function ($reason) use ($stage, $message, &$matched): void {
+            $matched = $matched || (
+                Arr::getPath((array) $reason, 'stage') === $stage
+                && (
+                    Str::isEmpty($message)
+                    || Arr::getPath((array) $reason, 'message') === $message
+                )
+            );
+        });
+
+        return $matched;
+    }
+
+    private function batchFailureIsRecoveredChildrenOnly(array $results): bool
+    {
+        $failed = Arr::make($results)
+            ->filter(fn ($result): bool => Flag::isFalse(Arr::getPath((array) $result, 'ok')))
+            ->values();
+
+        return $failed->isNotEmpty()
+            && $failed->filter(
+                fn ($result): bool => !$this->aggregateFailureIsOptionalHookOnly(Arr::make((array) $result))
+            )->isEmpty();
     }
 
     private function reason(string $code, string $stage, string $message): array

--- a/app/Business/Services/AddOnLifecycleReadinessService.php
+++ b/app/Business/Services/AddOnLifecycleReadinessService.php
@@ -203,8 +203,12 @@ final class AddOnLifecycleReadinessService extends Service
             $results,
             $aggregateStage
         );
+        $aggregateExplainedByChildren = $reasons->isNotEmpty()
+            && Str::isEmpty($aggregateStage)
+            && Str::isEmpty($aggregateError);
         $independentAggregateFailure = $aggregateFailed
             && !$recoveredChildFailuresOnly
+            && !$aggregateExplainedByChildren
             && !$this->hasMatchingReason($reasons, $aggregateStage, $aggregateError);
         if ($independentAggregateFailure) {
             $reasons->unshift($this->reason(

--- a/app/Business/Services/AddOnLifecycleReadinessService.php
+++ b/app/Business/Services/AddOnLifecycleReadinessService.php
@@ -75,16 +75,17 @@ final class AddOnLifecycleReadinessService extends Service
                 return;
             }
 
-            $error = (string) Arr::getPath($result, 'error', '');
+            $error = Str::make((string) Arr::getPath($result, 'error', ''))->trim()->val();
             $message = Str::isNotEmpty($error) ? $error : "Add-on {$stage} failed.";
             $reasons->push($this->reason($code, $stage, $message));
         });
 
         if ($this->hasIndependentAggregateFailure($outcome, $reasons, $optionalHookFailureOnly)) {
+            $aggregateError = Str::make((string) $outcome->get('error'))->trim()->val();
             $reasons->unshift($this->reason(
                 'addon_lifecycle_failed',
                 (string) ($outcome->get('stage') ?: 'lifecycle'),
-                (string) ($outcome->get('error') ?: 'Add-on lifecycle action failed.')
+                Str::isNotEmpty($aggregateError) ? $aggregateError : 'Add-on lifecycle action failed.'
             ));
         }
 
@@ -114,7 +115,7 @@ final class AddOnLifecycleReadinessService extends Service
     private function selectedReason(Arr $outcome, Arr $reasons): Arr
     {
         $stage = (string) $outcome->get('stage');
-        $message = (string) $outcome->get('error');
+        $message = Str::make((string) $outcome->get('error'))->trim()->val();
         $messageSelectsStage = $this->messageSelectsStage($stage)
             && Str::isNotEmpty($message);
         $matching = $reasons->filter(fn ($reason): bool =>
@@ -192,7 +193,7 @@ final class AddOnLifecycleReadinessService extends Service
         }
 
         $stage = (string) $outcome->get('stage');
-        $message = (string) $outcome->get('error');
+        $message = Str::make((string) $outcome->get('error'))->trim()->val();
         if (Str::isEmpty($stage) && Str::isEmpty($message)) {
             return false;
         }

--- a/app/Business/Services/AddOnLifecycleReadinessService.php
+++ b/app/Business/Services/AddOnLifecycleReadinessService.php
@@ -88,11 +88,11 @@ final class AddOnLifecycleReadinessService extends Service
         }
 
         if ($reasons->count() > 0) {
-            $first = Arr::make((array) $reasons->get(0));
+            $first = $this->selectedReason($outcome, $reasons);
             $outcome->set('ok', false);
             $outcome->set('stage', $first->get('stage'));
             $outcome->set('nextAction', 'retry_lifecycle');
-            $outcome->set('error', $outcome->get('error') ?: $first->get('message'));
+            $outcome->set('error', $first->get('message'));
         } elseif ($optionalHookFailureOnly) {
             $outcome->set('ok', true);
             $outcome->set('stage', 'complete');
@@ -108,6 +108,21 @@ final class AddOnLifecycleReadinessService extends Service
         ]);
 
         return $outcome->toArray();
+    }
+
+    private function selectedReason(Arr $outcome, Arr $reasons): Arr
+    {
+        $stage = (string) $outcome->get('stage');
+        $message = (string) $outcome->get('error');
+        $matching = $reasons->filter(fn ($reason): bool =>
+            Arr::getPath((array) $reason, 'stage') === $stage
+            && (
+                Str::isEmpty($message)
+                || Arr::getPath((array) $reason, 'message') === $message
+            )
+        )->values();
+
+        return Arr::make((array) ($matching->get(0) ?? $reasons->get(0)));
     }
 
     private function normalizeHook(Arr $hook, Arr $reasons): array
@@ -160,10 +175,15 @@ final class AddOnLifecycleReadinessService extends Service
 
         $stage = (string) ($outcome->get('stage') ?: 'lifecycle');
         $message = (string) $outcome->get('error');
-        $matched = $reasons->filter(fn ($reason): bool =>
-            Arr::getPath((array) $reason, 'stage') === $stage
-            || (Str::isNotEmpty($message) && Arr::getPath((array) $reason, 'message') === $message)
-        )->isNotEmpty();
+        $matched = false;
+        $reasons->each(function ($reason) use ($stage, $message, &$matched): void {
+            $matched = $matched
+                || Arr::getPath((array) $reason, 'stage') === $stage
+                || (
+                    Str::isNotEmpty($message)
+                    && Arr::getPath((array) $reason, 'message') === $message
+                );
+        });
 
         return !$matched
             && (Str::isNotEmpty($message) || !Arr::make(['complete', 'hook'])->contains($stage));

--- a/app/Business/Services/AddOnLifecycleReadinessService.php
+++ b/app/Business/Services/AddOnLifecycleReadinessService.php
@@ -185,7 +185,7 @@ final class AddOnLifecycleReadinessService extends Service
     {
         $aggregateFailed = Flag::isFalse($outcome->get('ok'));
         $aggregateStage = (string) ($outcome->get('stage') ?: 'lifecycle');
-        $aggregateError = (string) ($outcome->get('error') ?: 'Add-on lifecycle batch failed.');
+        $aggregateError = (string) $outcome->get('error');
         $normalized = Arr::make($results)
             ->map(fn ($result): array => $this->normalizeLifecycle(Arr::make((array) $result)))
             ->values();
@@ -199,7 +199,10 @@ final class AddOnLifecycleReadinessService extends Service
         $failures->each(function (array $result) use ($reasons): void {
             $reasons->mergeRecursive((array) Arr::getPath($result, 'readiness.reasons', []));
         });
-        $recoveredChildFailuresOnly = $this->batchFailureIsRecoveredChildrenOnly($results);
+        $recoveredChildFailuresOnly = $this->batchFailureIsRecoveredChildrenOnly(
+            $results,
+            $aggregateStage
+        );
         $independentAggregateFailure = $aggregateFailed
             && !$recoveredChildFailuresOnly
             && !$this->hasMatchingReason($reasons, $aggregateStage, $aggregateError);
@@ -207,7 +210,7 @@ final class AddOnLifecycleReadinessService extends Service
             $reasons->unshift($this->reason(
                 'addon_lifecycle_failed',
                 $aggregateStage,
-                $aggregateError
+                $aggregateError ?: 'Add-on lifecycle batch failed.'
             ));
         }
         $total = $normalized->count();
@@ -266,8 +269,11 @@ final class AddOnLifecycleReadinessService extends Service
         return $matched;
     }
 
-    private function batchFailureIsRecoveredChildrenOnly(array $results): bool
+    private function batchFailureIsRecoveredChildrenOnly(array $results, string $aggregateStage): bool
     {
+        if (!Arr::make(['', 'complete', 'hook'])->contains($aggregateStage)) {
+            return false;
+        }
         $failed = Arr::make($results)
             ->filter(fn ($result): bool => Flag::isFalse(Arr::getPath((array) $result, 'ok')))
             ->values();

--- a/app/Business/Services/AddOnLifecycleReadinessService.php
+++ b/app/Business/Services/AddOnLifecycleReadinessService.php
@@ -93,7 +93,7 @@ final class AddOnLifecycleReadinessService extends Service
             $first = $this->selectedReason($outcome, $reasons);
             $outcome->set('ok', false);
             $outcome->set('stage', $first->get('stage'));
-            $outcome->set('nextAction', 'retry_lifecycle');
+            $outcome->set('nextAction', $this->failedNextAction((string) $outcome->get('action')));
             $outcome->set('error', $first->get('message'));
         } elseif ($optionalHookFailureOnly) {
             $outcome->set('ok', true);
@@ -267,7 +267,7 @@ final class AddOnLifecycleReadinessService extends Service
             $first = $this->selectedReason($outcome, $reasons);
             $outcome->set('stage', $first->get('stage') ?: 'lifecycle');
             $outcome->set('error', $first->get('message') ?: 'Add-on lifecycle action failed.');
-            $outcome->set('nextAction', 'retry_lifecycle');
+            $outcome->set('nextAction', $this->failedNextAction((string) $outcome->get('action')));
         } else {
             $outcome->set('stage', 'complete');
             $outcome->set('error', null);
@@ -291,6 +291,15 @@ final class AddOnLifecycleReadinessService extends Service
         }
 
         return $action === 'install_all' ? 'activate_all' : null;
+    }
+
+    private function failedNextAction(string $action): string
+    {
+        $action = Str::make($action)->trim()->lower()->val();
+
+        return Arr::make(['uninstall', 'uninstall_all'])->contains($action)
+            ? 'reconcile_lifecycle'
+            : 'retry_lifecycle';
     }
 
     private function hasMatchingReason(Arr $reasons, string $stage, string $message): bool

--- a/app/Business/Services/AddOnLifecycleReadinessService.php
+++ b/app/Business/Services/AddOnLifecycleReadinessService.php
@@ -162,9 +162,19 @@ final class AddOnLifecycleReadinessService extends Service
             ->filter(fn ($hook): bool => Flag::isFalse(Arr::getPath((array) $hook, 'ok')))
             ->values();
         $stage = Str::make((string) $outcome->get('stage'))->trim()->lower()->val();
+        $error = Str::make((string) $outcome->get('error'))->trim()->val();
+        $failedMessages = $failed
+            ->map(fn ($hook): string => Str::make(
+                (string) Arr::getPath((array) $hook, 'error')
+            )->trim()->val())
+            ->filter(fn (string $message): bool => Str::isNotEmpty($message))
+            ->unique()
+            ->values();
+        $aggregateErrorIsOptional = Str::isEmpty($error)
+            || ($failedMessages->count() === 1 && $failedMessages->get(0) === $error);
 
         return $failed->isNotEmpty()
-            && Str::make((string) $outcome->get('error'))->trim()->isEmpty()
+            && $aggregateErrorIsOptional
             && Arr::make(['', 'complete', 'hook'])->contains($stage)
             && $failed->filter(fn ($hook): bool => Str::make(
                 (string) Arr::getPath((array) $hook, 'status')

--- a/app/Business/Services/AddOnLifecycleReadinessService.php
+++ b/app/Business/Services/AddOnLifecycleReadinessService.php
@@ -179,6 +179,10 @@ final class AddOnLifecycleReadinessService extends Service
             return false;
         }
 
+        if (Str::isEmpty($stage) && $this->hasMatchingReasonMessage($reasons, $message)) {
+            return false;
+        }
+
         $stage = $stage ?: 'lifecycle';
         $matched = $this->hasMatchingReason($reasons, $stage, $message);
 
@@ -209,8 +213,10 @@ final class AddOnLifecycleReadinessService extends Service
             $aggregateStage
         );
         $aggregateExplainedByChildren = $reasons->isNotEmpty()
-            && Str::isEmpty($aggregateStage)
-            && Str::isEmpty($aggregateError);
+            && Str::isEmpty($aggregateError)
+            && Arr::make(['', 'complete'])->contains(
+                Str::make($aggregateStage)->trim()->lower()->val()
+            );
         $independentAggregateFailure = $aggregateFailed
             && !$recoveredChildFailuresOnly
             && !$aggregateExplainedByChildren
@@ -273,6 +279,20 @@ final class AddOnLifecycleReadinessService extends Service
                     || Arr::getPath((array) $reason, 'message') === $message
                 )
             );
+        });
+
+        return $matched;
+    }
+
+    private function hasMatchingReasonMessage(Arr $reasons, string $message): bool
+    {
+        if (Str::isEmpty($message)) {
+            return false;
+        }
+
+        $matched = false;
+        $reasons->each(function ($reason) use ($message, &$matched): void {
+            $matched = $matched || Arr::getPath((array) $reason, 'message') === $message;
         });
 
         return $matched;

--- a/app/Business/Services/AddOnLifecycleReadinessService.php
+++ b/app/Business/Services/AddOnLifecycleReadinessService.php
@@ -63,7 +63,7 @@ final class AddOnLifecycleReadinessService extends Service
     private function normalizeLifecycle(Arr $outcome): array
     {
         $reasons = Arr::make([]);
-        $optionalHookFailureOnly = $this->hasOnlyMissingOptionalHookFailures($outcome);
+        $optionalHookFailureOnly = $this->aggregateFailureIsOptionalHookOnly($outcome);
         $hooks = Arr::make(Arr::is($outcome->get('hooks')) ? $outcome->get('hooks') : [])
             ->map(fn ($hook): array => $this->normalizeHook(Arr::make((array) $hook), $reasons))
             ->values();
@@ -133,13 +133,16 @@ final class AddOnLifecycleReadinessService extends Service
         return $hook->toArray();
     }
 
-    private function hasOnlyMissingOptionalHookFailures(Arr $outcome): bool
+    private function aggregateFailureIsOptionalHookOnly(Arr $outcome): bool
     {
         $failed = Arr::make(Arr::is($outcome->get('hooks')) ? $outcome->get('hooks') : [])
             ->filter(fn ($hook): bool => Flag::isFalse(Arr::getPath((array) $hook, 'ok')))
             ->values();
+        $stage = Str::make((string) $outcome->get('stage'))->trim()->lower()->val();
 
         return $failed->isNotEmpty()
+            && Str::make((string) $outcome->get('error'))->trim()->isEmpty()
+            && Arr::make(['', 'complete', 'hook'])->contains($stage)
             && $failed->filter(fn ($hook): bool => Str::make(
                 (string) Arr::getPath((array) $hook, 'status')
             )->trim()->lower()->val() !== 'missing_callable')->isEmpty();
@@ -171,6 +174,12 @@ final class AddOnLifecycleReadinessService extends Service
         $outcome->set('results', $normalized->toArray());
         if ($failed > 0) {
             $outcome->set('nextAction', 'retry_lifecycle');
+        } else {
+            $outcome->set('stage', 'complete');
+            $outcome->set('error', null);
+            if ((string) $outcome->get('nextAction') === 'retry_lifecycle') {
+                $outcome->set('nextAction', $this->successfulBatchNextAction((string) $outcome->get('action')));
+            }
         }
         $outcome->set('readiness', [
             'state' => $failed === 0 ? 'ready' : 'blocked',
@@ -178,6 +187,13 @@ final class AddOnLifecycleReadinessService extends Service
         ]);
 
         return $outcome->toArray();
+    }
+
+    private function successfulBatchNextAction(string $action): ?string
+    {
+        return Str::make($action)->trim()->lower()->val() === 'install_all'
+            ? 'activate_all'
+            : null;
     }
 
     private function reason(string $code, string $stage, string $message): array

--- a/app/Business/Services/AddOnLifecycleReadinessService.php
+++ b/app/Business/Services/AddOnLifecycleReadinessService.php
@@ -148,10 +148,11 @@ final class AddOnLifecycleReadinessService extends Service
         }
 
         if (Flag::isFalse($hook->get('ok'))) {
+            $error = Str::make((string) $hook->get('error'))->trim()->val();
             $reasons->push($this->reason(
                 'addon_hook_failed',
                 'hook',
-                (string) ($hook->get('error') ?: 'Add-on lifecycle hook failed.')
+                Str::isNotEmpty($error) ? $error : 'Add-on lifecycle hook failed.'
             ));
         }
 
@@ -215,7 +216,7 @@ final class AddOnLifecycleReadinessService extends Service
     {
         $aggregateFailed = Flag::isFalse($outcome->get('ok'));
         $aggregateStage = (string) $outcome->get('stage');
-        $aggregateError = (string) $outcome->get('error');
+        $aggregateError = Str::make((string) $outcome->get('error'))->trim()->val();
         $normalized = Arr::make($results)
             ->map(fn ($result): array => $this->normalizeLifecycle(Arr::make((array) $result)))
             ->values();

--- a/app/Business/Services/AddOnLifecycleReadinessService.php
+++ b/app/Business/Services/AddOnLifecycleReadinessService.php
@@ -63,6 +63,7 @@ final class AddOnLifecycleReadinessService extends Service
     private function normalizeLifecycle(Arr $outcome): array
     {
         $reasons = Arr::make([]);
+        $optionalHookFailureOnly = $this->hasOnlyMissingOptionalHookFailures($outcome);
         $hooks = Arr::make(Arr::is($outcome->get('hooks')) ? $outcome->get('hooks') : [])
             ->map(fn ($hook): array => $this->normalizeHook(Arr::make((array) $hook), $reasons))
             ->values();
@@ -78,7 +79,10 @@ final class AddOnLifecycleReadinessService extends Service
             $reasons->push($this->reason($code, $stage, $message));
         });
 
-        if (Flag::isFalse($outcome->get('ok')) && $reasons->count() === 0) {
+        if (Flag::isFalse($outcome->get('ok'))
+            && $reasons->count() === 0
+            && !$optionalHookFailureOnly
+        ) {
             $reasons->push($this->reason(
                 'addon_lifecycle_failed',
                 (string) ($outcome->get('stage') ?: 'lifecycle'),
@@ -90,8 +94,11 @@ final class AddOnLifecycleReadinessService extends Service
             $first = Arr::make((array) $reasons->get(0));
             $outcome->set('ok', false);
             $outcome->set('stage', $first->get('stage'));
-            $outcome->set('nextAction', $outcome->get('nextAction') ?: 'retry_lifecycle');
+            $outcome->set('nextAction', 'retry_lifecycle');
             $outcome->set('error', $outcome->get('error') ?: $first->get('message'));
+        } elseif ($optionalHookFailureOnly) {
+            $outcome->set('ok', true);
+            $outcome->set('error', null);
         }
 
         $outcome->set('readiness', [
@@ -126,6 +133,18 @@ final class AddOnLifecycleReadinessService extends Service
         return $hook->toArray();
     }
 
+    private function hasOnlyMissingOptionalHookFailures(Arr $outcome): bool
+    {
+        $failed = Arr::make(Arr::is($outcome->get('hooks')) ? $outcome->get('hooks') : [])
+            ->filter(fn ($hook): bool => Flag::isFalse(Arr::getPath((array) $hook, 'ok')))
+            ->values();
+
+        return $failed->isNotEmpty()
+            && $failed->filter(fn ($hook): bool => Str::make(
+                (string) Arr::getPath((array) $hook, 'status')
+            )->trim()->lower()->val() !== 'missing_callable')->isEmpty();
+    }
+
     private function normalizeBatch(Arr $outcome, array $results): array
     {
         $normalized = Arr::make($results)
@@ -150,6 +169,9 @@ final class AddOnLifecycleReadinessService extends Service
         $outcome->set('succeeded', $total - $failed);
         $outcome->set('failed', $failed);
         $outcome->set('results', $normalized->toArray());
+        if ($failed > 0) {
+            $outcome->set('nextAction', 'retry_lifecycle');
+        }
         $outcome->set('readiness', [
             'state' => $failed === 0 ? 'ready' : 'blocked',
             'reasons' => $reasons->toArray(),

--- a/app/Business/Services/AddOnLifecycleReadinessService.php
+++ b/app/Business/Services/AddOnLifecycleReadinessService.php
@@ -173,8 +173,13 @@ final class AddOnLifecycleReadinessService extends Service
             return true;
         }
 
-        $stage = (string) ($outcome->get('stage') ?: 'lifecycle');
+        $stage = (string) $outcome->get('stage');
         $message = (string) $outcome->get('error');
+        if (Str::isEmpty($stage) && Str::isEmpty($message)) {
+            return false;
+        }
+
+        $stage = $stage ?: 'lifecycle';
         $matched = $this->hasMatchingReason($reasons, $stage, $message);
 
         return !$matched

--- a/app/Business/Services/AddOnLifecycleReadinessService.php
+++ b/app/Business/Services/AddOnLifecycleReadinessService.php
@@ -115,7 +115,7 @@ final class AddOnLifecycleReadinessService extends Service
         $stage = (string) $outcome->get('stage');
         $message = (string) $outcome->get('error');
         $matching = $reasons->filter(fn ($reason): bool =>
-            Arr::getPath((array) $reason, 'stage') === $stage
+            (Str::isEmpty($stage) || Arr::getPath((array) $reason, 'stage') === $stage)
             && (
                 Str::isEmpty($message)
                 || Arr::getPath((array) $reason, 'message') === $message
@@ -217,10 +217,13 @@ final class AddOnLifecycleReadinessService extends Service
             && Arr::make(['', 'complete'])->contains(
                 Str::make($aggregateStage)->trim()->lower()->val()
             );
+        $aggregateMatchesChild = $this->hasMatchingReason($reasons, $aggregateStage, $aggregateError)
+            || (Str::isEmpty($aggregateStage)
+                && $this->hasMatchingReasonMessage($reasons, $aggregateError));
         $independentAggregateFailure = $aggregateFailed
             && !$recoveredChildFailuresOnly
             && !$aggregateExplainedByChildren
-            && !$this->hasMatchingReason($reasons, $aggregateStage, $aggregateError);
+            && !$aggregateMatchesChild;
         if ($independentAggregateFailure) {
             $reasons->unshift($this->reason(
                 'addon_lifecycle_failed',

--- a/app/Business/Services/AddOnLifecycleReadinessService.php
+++ b/app/Business/Services/AddOnLifecycleReadinessService.php
@@ -184,7 +184,7 @@ final class AddOnLifecycleReadinessService extends Service
     private function normalizeBatch(Arr $outcome, array $results): array
     {
         $aggregateFailed = Flag::isFalse($outcome->get('ok'));
-        $aggregateStage = (string) ($outcome->get('stage') ?: 'lifecycle');
+        $aggregateStage = (string) $outcome->get('stage');
         $aggregateError = (string) $outcome->get('error');
         $normalized = Arr::make($results)
             ->map(fn ($result): array => $this->normalizeLifecycle(Arr::make((array) $result)))
@@ -209,7 +209,7 @@ final class AddOnLifecycleReadinessService extends Service
         if ($independentAggregateFailure) {
             $reasons->unshift($this->reason(
                 'addon_lifecycle_failed',
-                $aggregateStage,
+                $aggregateStage ?: 'lifecycle',
                 $aggregateError ?: 'Add-on lifecycle batch failed.'
             ));
         }

--- a/app/Business/Services/AddOnLifecycleReadinessService.php
+++ b/app/Business/Services/AddOnLifecycleReadinessService.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Business\Services;
+
+use BlueFission\Arr;
+use BlueFission\Flag;
+use BlueFission\Services\Service;
+use BlueFission\Str;
+
+final class AddOnLifecycleReadinessService extends Service
+{
+    private const REQUIRED_STAGES = [
+        'migrations' => 'addon_migration_failed',
+        'population' => 'addon_population_failed',
+    ];
+
+    public function normalize(array $outcome): array
+    {
+        $outcome = Arr::make($outcome);
+        $results = $outcome->get('results');
+        if (Arr::is($results)) {
+            return $this->normalizeBatch($outcome, (array) $results);
+        }
+
+        return $this->normalizeLifecycle($outcome);
+    }
+
+    public function failure(string $action, string $code, string $message): array
+    {
+        return [
+            'ok' => false,
+            'action' => $action,
+            'changed' => false,
+            'stage' => 'request',
+            'nextAction' => 'correct_request',
+            'error' => $message,
+            'messages' => [$message],
+            'hooks' => [],
+            'readiness' => [
+                'state' => 'blocked',
+                'reasons' => [$this->reason($code, 'request', $message)],
+            ],
+        ];
+    }
+
+    public function listing(array $addOns): array
+    {
+        return [
+            'ok' => true,
+            'action' => 'show_all',
+            'changed' => false,
+            'total' => Arr::size($addOns),
+            'results' => Arr::make($addOns)->values()->toArray(),
+            'readiness' => [
+                'state' => 'ready',
+                'reasons' => [],
+            ],
+        ];
+    }
+
+    private function normalizeLifecycle(Arr $outcome): array
+    {
+        $reasons = Arr::make([]);
+        $hooks = Arr::make(Arr::is($outcome->get('hooks')) ? $outcome->get('hooks') : [])
+            ->map(fn ($hook): array => $this->normalizeHook(Arr::make((array) $hook), $reasons))
+            ->values();
+        $outcome->set('hooks', $hooks->toArray());
+
+        Arr::make(self::REQUIRED_STAGES)->each(function (string $code, string $stage) use ($outcome, $reasons): void {
+            $result = $outcome->get($stage);
+            if (!Arr::is($result) || !Arr::hasKey($result, 'ok') || !Flag::isFalse(Arr::getPath($result, 'ok'))) {
+                return;
+            }
+
+            $message = (string) Arr::getPath($result, 'error', "Add-on {$stage} failed.");
+            $reasons->push($this->reason($code, $stage, $message));
+        });
+
+        if (Flag::isFalse($outcome->get('ok')) && $reasons->count() === 0) {
+            $reasons->push($this->reason(
+                'addon_lifecycle_failed',
+                (string) ($outcome->get('stage') ?: 'lifecycle'),
+                (string) ($outcome->get('error') ?: 'Add-on lifecycle action failed.')
+            ));
+        }
+
+        if ($reasons->count() > 0) {
+            $first = Arr::make((array) $reasons->get(0));
+            $outcome->set('ok', false);
+            $outcome->set('stage', $first->get('stage'));
+            $outcome->set('nextAction', $outcome->get('nextAction') ?: 'retry_lifecycle');
+            $outcome->set('error', $outcome->get('error') ?: $first->get('message'));
+        }
+
+        $outcome->set('readiness', [
+            'state' => $reasons->count() === 0 ? 'ready' : 'blocked',
+            'reasons' => $reasons->toArray(),
+        ]);
+
+        return $outcome->toArray();
+    }
+
+    private function normalizeHook(Arr $hook, Arr $reasons): array
+    {
+        $status = Str::make((string) $hook->get('status'))->trim()->lower()->val();
+        if ($status === 'missing_callable') {
+            $hook->set('ok', true);
+            $hook->set('status', 'skipped');
+            $hook->set('optional', true);
+            $hook->set('reason', 'lifecycle_hook_not_declared');
+            $hook->set('error', null);
+
+            return $hook->toArray();
+        }
+
+        if (Flag::isFalse($hook->get('ok'))) {
+            $reasons->push($this->reason(
+                'addon_hook_failed',
+                'hook',
+                (string) ($hook->get('error') ?: 'Add-on lifecycle hook failed.')
+            ));
+        }
+
+        return $hook->toArray();
+    }
+
+    private function normalizeBatch(Arr $outcome, array $results): array
+    {
+        $normalized = Arr::make($results)
+            ->map(fn ($result): array => $this->normalizeLifecycle(Arr::make((array) $result)))
+            ->values();
+        $failures = $normalized
+            ->filter(fn (array $result): bool => Flag::isFalse(Arr::getPath($result, 'ok', false)))
+            ->values();
+        $changes = $normalized
+            ->filter(fn (array $result): bool => Flag::parseBool(Arr::getPath($result, 'changed', false)))
+            ->values();
+        $reasons = Arr::make([]);
+        $failures->each(function (array $result) use ($reasons): void {
+            $reasons->mergeRecursive((array) Arr::getPath($result, 'readiness.reasons', []));
+        });
+        $total = $normalized->count();
+        $failed = $failures->count();
+
+        $outcome->set('ok', $failed === 0);
+        $outcome->set('changed', $changes->count() > 0);
+        $outcome->set('total', $total);
+        $outcome->set('succeeded', $total - $failed);
+        $outcome->set('failed', $failed);
+        $outcome->set('results', $normalized->toArray());
+        $outcome->set('readiness', [
+            'state' => $failed === 0 ? 'ready' : 'blocked',
+            'reasons' => $reasons->toArray(),
+        ]);
+
+        return $outcome->toArray();
+    }
+
+    private function reason(string $code, string $stage, string $message): array
+    {
+        return [
+            'code' => $code,
+            'stage' => $stage,
+            'message' => $message,
+        ];
+    }
+}

--- a/app/Business/Services/AddOnLifecycleReadinessService.php
+++ b/app/Business/Services/AddOnLifecycleReadinessService.php
@@ -75,7 +75,8 @@ final class AddOnLifecycleReadinessService extends Service
                 return;
             }
 
-            $message = (string) Arr::getPath($result, 'error', "Add-on {$stage} failed.");
+            $error = (string) Arr::getPath($result, 'error', '');
+            $message = Str::isNotEmpty($error) ? $error : "Add-on {$stage} failed.";
             $reasons->push($this->reason($code, $stage, $message));
         });
 

--- a/app/Business/Services/AddOnLifecycleReadinessService.php
+++ b/app/Business/Services/AddOnLifecycleReadinessService.php
@@ -79,11 +79,8 @@ final class AddOnLifecycleReadinessService extends Service
             $reasons->push($this->reason($code, $stage, $message));
         });
 
-        if (Flag::isFalse($outcome->get('ok'))
-            && $reasons->count() === 0
-            && !$optionalHookFailureOnly
-        ) {
-            $reasons->push($this->reason(
+        if ($this->hasIndependentAggregateFailure($outcome, $reasons, $optionalHookFailureOnly)) {
+            $reasons->unshift($this->reason(
                 'addon_lifecycle_failed',
                 (string) ($outcome->get('stage') ?: 'lifecycle'),
                 (string) ($outcome->get('error') ?: 'Add-on lifecycle action failed.')
@@ -98,7 +95,11 @@ final class AddOnLifecycleReadinessService extends Service
             $outcome->set('error', $outcome->get('error') ?: $first->get('message'));
         } elseif ($optionalHookFailureOnly) {
             $outcome->set('ok', true);
+            $outcome->set('stage', 'complete');
             $outcome->set('error', null);
+            if ((string) $outcome->get('nextAction') === 'retry_lifecycle') {
+                $outcome->set('nextAction', $this->successfulNextAction((string) $outcome->get('action')));
+            }
         }
 
         $outcome->set('readiness', [
@@ -148,6 +149,26 @@ final class AddOnLifecycleReadinessService extends Service
             )->trim()->lower()->val() !== 'missing_callable')->isEmpty();
     }
 
+    private function hasIndependentAggregateFailure(Arr $outcome, Arr $reasons, bool $optionalHookFailureOnly): bool
+    {
+        if (!Flag::isFalse($outcome->get('ok')) || $optionalHookFailureOnly) {
+            return false;
+        }
+        if ($reasons->isEmpty()) {
+            return true;
+        }
+
+        $stage = (string) ($outcome->get('stage') ?: 'lifecycle');
+        $message = (string) $outcome->get('error');
+        $matched = $reasons->filter(fn ($reason): bool =>
+            Arr::getPath((array) $reason, 'stage') === $stage
+            || (Str::isNotEmpty($message) && Arr::getPath((array) $reason, 'message') === $message)
+        )->isNotEmpty();
+
+        return !$matched
+            && (Str::isNotEmpty($message) || !Arr::make(['complete', 'hook'])->contains($stage));
+    }
+
     private function normalizeBatch(Arr $outcome, array $results): array
     {
         $normalized = Arr::make($results)
@@ -178,7 +199,7 @@ final class AddOnLifecycleReadinessService extends Service
             $outcome->set('stage', 'complete');
             $outcome->set('error', null);
             if ((string) $outcome->get('nextAction') === 'retry_lifecycle') {
-                $outcome->set('nextAction', $this->successfulBatchNextAction((string) $outcome->get('action')));
+                $outcome->set('nextAction', $this->successfulNextAction((string) $outcome->get('action')));
             }
         }
         $outcome->set('readiness', [
@@ -189,11 +210,14 @@ final class AddOnLifecycleReadinessService extends Service
         return $outcome->toArray();
     }
 
-    private function successfulBatchNextAction(string $action): ?string
+    private function successfulNextAction(string $action): ?string
     {
-        return Str::make($action)->trim()->lower()->val() === 'install_all'
-            ? 'activate_all'
-            : null;
+        $action = Str::make($action)->trim()->lower()->val();
+        if ($action === 'install') {
+            return 'activate';
+        }
+
+        return $action === 'install_all' ? 'activate_all' : null;
     }
 
     private function reason(string $code, string $stage, string $message): array

--- a/app/Business/Services/AddOnLifecycleReadinessService.php
+++ b/app/Business/Services/AddOnLifecycleReadinessService.php
@@ -194,6 +194,9 @@ final class AddOnLifecycleReadinessService extends Service
         $outcome->set('failed', $failed);
         $outcome->set('results', $normalized->toArray());
         if ($failed > 0) {
+            $first = Arr::make((array) $reasons->get(0));
+            $outcome->set('stage', $first->get('stage') ?: 'lifecycle');
+            $outcome->set('error', $first->get('message') ?: 'Add-on lifecycle action failed.');
             $outcome->set('nextAction', 'retry_lifecycle');
         } else {
             $outcome->set('stage', 'complete');

--- a/app/Business/Services/AddOnLifecycleReadinessService.php
+++ b/app/Business/Services/AddOnLifecycleReadinessService.php
@@ -114,8 +114,15 @@ final class AddOnLifecycleReadinessService extends Service
     {
         $stage = (string) $outcome->get('stage');
         $message = (string) $outcome->get('error');
+        $messageSelectsStage = $this->messageSelectsStage($stage)
+            && Str::isNotEmpty($message);
         $matching = $reasons->filter(fn ($reason): bool =>
-            (Str::isEmpty($stage) || Arr::getPath((array) $reason, 'stage') === $stage)
+            (
+                Str::isEmpty($stage)
+                || Arr::getPath((array) $reason, 'stage') === $stage
+                || ($messageSelectsStage
+                    && Arr::getPath((array) $reason, 'message') === $message)
+            )
             && (
                 Str::isEmpty($message)
                 || Arr::getPath((array) $reason, 'message') === $message
@@ -179,7 +186,9 @@ final class AddOnLifecycleReadinessService extends Service
             return false;
         }
 
-        if (Str::isEmpty($stage) && $this->hasMatchingReasonMessage($reasons, $message)) {
+        if ($this->messageSelectsStage($stage)
+            && $this->hasMatchingReasonMessage($reasons, $message)
+        ) {
             return false;
         }
 
@@ -218,7 +227,7 @@ final class AddOnLifecycleReadinessService extends Service
                 Str::make($aggregateStage)->trim()->lower()->val()
             );
         $aggregateMatchesChild = $this->hasMatchingReason($reasons, $aggregateStage, $aggregateError)
-            || (Str::isEmpty($aggregateStage)
+            || ($this->messageSelectsStage($aggregateStage)
                 && $this->hasMatchingReasonMessage($reasons, $aggregateError));
         $independentAggregateFailure = $aggregateFailed
             && !$recoveredChildFailuresOnly
@@ -299,6 +308,13 @@ final class AddOnLifecycleReadinessService extends Service
         });
 
         return $matched;
+    }
+
+    private function messageSelectsStage(string $stage): bool
+    {
+        return Arr::make(['', 'complete'])->contains(
+            Str::make($stage)->trim()->lower()->val()
+        );
     }
 
     private function batchFailureIsRecoveredChildrenOnly(array $results, string $aggregateStage): bool

--- a/mapping/console.php
+++ b/mapping/console.php
@@ -25,8 +25,10 @@ $app->register('database', 'populate', 'populate');
 
 $app->delegate('addon', AddOnManager::class);
 $app->register('addon', 'install', 'install');
+$app->register('addon', 'install-all', 'install_all');
 $app->register('addon', 'uninstall', 'uninstall');
 $app->register('addon', 'activate', 'activate');
+$app->register('addon', 'activate-all', 'activate_all');
 $app->register('addon', 'deactivate', 'deactivate');
 $app->register('addon', 'show', 'showAll');
 

--- a/tests/Unit/Business/Console/AddOnManagerTest.php
+++ b/tests/Unit/Business/Console/AddOnManagerTest.php
@@ -34,7 +34,7 @@ final class AddOnManagerTest extends TestCase
 
         $this->assertSame('', $output);
         $this->assertFalse($result['ok']);
-        $this->assertSame('sample', $result['addon']);
+        $this->assertSame('Sample', $result['addon']);
         $this->assertSame('addon_migration_failed', $result['readiness']['reasons'][0]['code']);
     }
 

--- a/tests/Unit/Business/Console/AddOnManagerTest.php
+++ b/tests/Unit/Business/Console/AddOnManagerTest.php
@@ -49,6 +49,23 @@ final class AddOnManagerTest extends TestCase
         $this->assertSame('addon_name_required', $result['readiness']['reasons'][0]['code']);
     }
 
+    public function testFalseAddOnLookupReturnsStableNotFoundFailure(): void
+    {
+        $manager = new class {
+            public function getAddOnData(string $name): bool
+            {
+                return false;
+            }
+        };
+        $command = new AddOnManager($manager);
+
+        $result = $command->activate((object) ['context' => ['data' => 'Missing']]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('addon_not_found', $result['readiness']['reasons'][0]['code']);
+        $this->assertSame('request', $result['stage']);
+    }
+
     public function testShowReturnsAStableCollectionSummary(): void
     {
         $manager = new class {

--- a/tests/Unit/Business/Console/AddOnManagerTest.php
+++ b/tests/Unit/Business/Console/AddOnManagerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Business\Console;
+
+use App\Business\Console\AddOnManager;
+use PHPUnit\Framework\TestCase;
+
+final class AddOnManagerTest extends TestCase
+{
+    public function testInstallReturnsStructuredReadinessWithoutRenderingArrays(): void
+    {
+        $manager = new class {
+            public function install(string $name): array
+            {
+                return [
+                    'ok' => true,
+                    'action' => 'install',
+                    'addon' => $name,
+                    'changed' => false,
+                    'hooks' => [],
+                    'migrations' => ['ok' => false, 'error' => 'Schema failed.'],
+                    'population' => [],
+                ];
+            }
+        };
+        $command = new AddOnManager($manager);
+        $behavior = (object) ['context' => ['data' => 'Sample']];
+
+        ob_start();
+        $result = $command->install($behavior);
+        $output = ob_get_clean();
+
+        $this->assertSame('', $output);
+        $this->assertFalse($result['ok']);
+        $this->assertSame('sample', $result['addon']);
+        $this->assertSame('addon_migration_failed', $result['readiness']['reasons'][0]['code']);
+    }
+
+    public function testMissingAddOnNameReturnsStableRequestFailure(): void
+    {
+        $command = new AddOnManager(new \stdClass());
+
+        $result = $command->install((object) ['context' => []]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('request', $result['stage']);
+        $this->assertSame('addon_name_required', $result['readiness']['reasons'][0]['code']);
+    }
+
+    public function testShowReturnsAStableCollectionSummary(): void
+    {
+        $manager = new class {
+            public function showAllAddOns(): array
+            {
+                return [
+                    'first' => (object) ['name' => 'first'],
+                    'second' => (object) ['name' => 'second'],
+                ];
+            }
+        };
+        $command = new AddOnManager($manager);
+
+        $result = $command->showAll();
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame(2, $result['total']);
+        $this->assertCount(2, $result['results']);
+    }
+}

--- a/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
@@ -17,6 +17,7 @@ final class AddOnLifecycleReadinessServiceTest extends TestCase
             'addon' => 'sample',
             'changed' => true,
             'stage' => 'complete',
+            'nextAction' => 'activate',
             'hooks' => [],
             'migrations' => [
                 'ok' => false,
@@ -29,16 +30,18 @@ final class AddOnLifecycleReadinessServiceTest extends TestCase
         $this->assertSame('migrations', $result['stage']);
         $this->assertSame('blocked', $result['readiness']['state']);
         $this->assertSame('addon_migration_failed', $result['readiness']['reasons'][0]['code']);
+        $this->assertSame('retry_lifecycle', $result['nextAction']);
     }
 
     public function testAbsentOptionalHookIsReportedAsSkippedWithoutContradictingSuccess(): void
     {
         $result = (new AddOnLifecycleReadinessService())->normalize([
-            'ok' => true,
+            'ok' => false,
             'action' => 'install',
             'addon' => 'sample',
             'changed' => true,
             'stage' => 'complete',
+            'nextAction' => 'activate',
             'hooks' => [[
                 'ok' => false,
                 'hook' => 'install',
@@ -55,6 +58,7 @@ final class AddOnLifecycleReadinessServiceTest extends TestCase
         $this->assertSame('skipped', $result['hooks'][0]['status']);
         $this->assertSame('lifecycle_hook_not_declared', $result['hooks'][0]['reason']);
         $this->assertNull($result['hooks'][0]['error']);
+        $this->assertSame('activate', $result['nextAction']);
     }
 
     public function testRequiredHookResolutionFailureBlocksLifecycleReadiness(): void
@@ -86,6 +90,7 @@ final class AddOnLifecycleReadinessServiceTest extends TestCase
             'total' => 2,
             'succeeded' => 2,
             'failed' => 0,
+            'nextAction' => 'activate_all',
             'results' => [
                 [
                     'ok' => true,
@@ -115,5 +120,6 @@ final class AddOnLifecycleReadinessServiceTest extends TestCase
         $this->assertTrue($result['changed']);
         $this->assertSame('blocked', $result['readiness']['state']);
         $this->assertFalse($result['results'][1]['ok']);
+        $this->assertSame('retry_lifecycle', $result['nextAction']);
     }
 }

--- a/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
@@ -148,6 +148,27 @@ final class AddOnLifecycleReadinessServiceTest extends TestCase
         $this->assertSame('addon_hook_failed', $result['readiness']['reasons'][1]['code']);
     }
 
+    public function testWhitespaceOnlyRequiredHookErrorUsesTheStableFallback(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => false,
+            'action' => 'install',
+            'stage' => 'hook',
+            'hooks' => [[
+                'ok' => false,
+                'status' => 'failed',
+                'error' => " \t ",
+            ]],
+        ]);
+
+        $this->assertSame('hook', $result['stage']);
+        $this->assertSame('Add-on lifecycle hook failed.', $result['error']);
+        $this->assertSame(
+            'Add-on lifecycle hook failed.',
+            $result['readiness']['reasons'][0]['message']
+        );
+    }
+
     public function testRecoveredSingleHookClearsFailureMetadata(): void
     {
         $result = (new AddOnLifecycleReadinessService())->normalize([
@@ -361,6 +382,26 @@ final class AddOnLifecycleReadinessServiceTest extends TestCase
             'ok' => false,
             'action' => 'install_all',
             'stage' => 'migrations',
+            'results' => [[
+                'ok' => false,
+                'action' => 'install',
+                'stage' => 'migrations',
+                'migrations' => ['ok' => false, 'error' => 'Schema failed.'],
+            ]],
+        ]);
+
+        $this->assertSame('migrations', $result['stage']);
+        $this->assertSame('Schema failed.', $result['error']);
+        $this->assertCount(1, $result['readiness']['reasons']);
+    }
+
+    public function testWhitespaceOnlyBatchErrorUsesTheActionableChildFailure(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => false,
+            'action' => 'install_all',
+            'stage' => 'migrations',
+            'error' => " \n ",
             'results' => [[
                 'ok' => false,
                 'action' => 'install',

--- a/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
@@ -368,4 +368,18 @@ final class AddOnLifecycleReadinessServiceTest extends TestCase
         $this->assertSame('Schema failed.', $result['error']);
         $this->assertCount(1, $result['readiness']['reasons']);
     }
+
+    public function testUnstagedSingleOutcomeUsesItsActionableChildFailure(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => false,
+            'action' => 'install',
+            'migrations' => ['ok' => false, 'error' => 'Schema failed.'],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('migrations', $result['stage']);
+        $this->assertSame('Schema failed.', $result['error']);
+        $this->assertCount(1, $result['readiness']['reasons']);
+    }
 }

--- a/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
@@ -148,6 +148,20 @@ final class AddOnLifecycleReadinessServiceTest extends TestCase
         $this->assertSame('addon_hook_failed', $result['readiness']['reasons'][1]['code']);
     }
 
+    public function testFailedUninstallRequiresLifecycleReconciliation(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => false,
+            'action' => 'uninstall',
+            'stage' => 'dependencies',
+            'error' => 'Dependency removal failed.',
+            'hooks' => [],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('reconcile_lifecycle', $result['nextAction']);
+    }
+
     public function testWhitespaceOnlyRequiredHookErrorUsesTheStableFallback(): void
     {
         $result = (new AddOnLifecycleReadinessService())->normalize([
@@ -331,6 +345,20 @@ final class AddOnLifecycleReadinessServiceTest extends TestCase
         $this->assertSame('Add-on discovery failed.', $result['error']);
         $this->assertSame('blocked', $result['readiness']['state']);
         $this->assertSame('addon_lifecycle_failed', $result['readiness']['reasons'][0]['code']);
+    }
+
+    public function testFailedBulkUninstallRequiresLifecycleReconciliation(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => false,
+            'action' => 'uninstall_all',
+            'stage' => 'dependencies',
+            'error' => 'Dependency removal failed.',
+            'results' => [],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('reconcile_lifecycle', $result['nextAction']);
     }
 
     public function testAggregateFailureWithSharedMessageAndDifferentStageRemainsIndependent(): void

--- a/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
@@ -398,6 +398,41 @@ final class AddOnLifecycleReadinessServiceTest extends TestCase
         $this->assertCount(1, $result['readiness']['reasons']);
     }
 
+    public function testUnstagedSingleAggregateErrorSelectsItsMatchingChildFailure(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => false,
+            'action' => 'install',
+            'error' => 'Population failed.',
+            'migrations' => ['ok' => false, 'error' => 'Schema failed.'],
+            'population' => ['ok' => false, 'error' => 'Population failed.'],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('population', $result['stage']);
+        $this->assertSame('Population failed.', $result['error']);
+        $this->assertCount(2, $result['readiness']['reasons']);
+    }
+
+    public function testUnstagedBatchAggregateErrorMatchesItsChildFailure(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => false,
+            'action' => 'install_all',
+            'error' => 'Population failed.',
+            'results' => [[
+                'ok' => false,
+                'action' => 'install',
+                'population' => ['ok' => false, 'error' => 'Population failed.'],
+            ]],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('population', $result['stage']);
+        $this->assertSame('Population failed.', $result['error']);
+        $this->assertCount(1, $result['readiness']['reasons']);
+    }
+
     public function testTerminalBatchStageUsesItsActionableChildFailure(): void
     {
         $result = (new AddOnLifecycleReadinessService())->normalize([

--- a/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
@@ -155,6 +155,33 @@ final class AddOnLifecycleReadinessServiceTest extends TestCase
         $this->assertNull($result['error']);
     }
 
+    public function testCopiedOptionalHookErrorIsRecovered(): void
+    {
+        $message = 'No compatible lifecycle hook callable was found.';
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => false,
+            'action' => 'install',
+            'addon' => 'sample',
+            'changed' => true,
+            'stage' => 'hook',
+            'error' => $message,
+            'nextAction' => 'retry_lifecycle',
+            'hooks' => [[
+                'ok' => false,
+                'hook' => 'install',
+                'status' => 'missing_callable',
+                'error' => $message,
+            ]],
+            'migrations' => ['ok' => true],
+            'population' => ['ok' => true],
+        ]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame('complete', $result['stage']);
+        $this->assertNull($result['error']);
+        $this->assertSame('ready', $result['readiness']['state']);
+    }
+
     public function testMultipleRequiredFailuresKeepTheSelectedStageAndErrorAligned(): void
     {
         $result = (new AddOnLifecycleReadinessService())->normalize([

--- a/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
@@ -249,4 +249,40 @@ final class AddOnLifecycleReadinessServiceTest extends TestCase
         $this->assertSame('activate_all', $result['nextAction']);
         $this->assertSame('ready', $result['readiness']['state']);
     }
+
+    public function testBatchPreservesAnIndependentFailureWithoutFailedChildren(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => false,
+            'action' => 'install_all',
+            'stage' => 'discovery',
+            'error' => 'Add-on discovery failed.',
+            'results' => [],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('discovery', $result['stage']);
+        $this->assertSame('Add-on discovery failed.', $result['error']);
+        $this->assertSame('blocked', $result['readiness']['state']);
+        $this->assertSame('addon_lifecycle_failed', $result['readiness']['reasons'][0]['code']);
+    }
+
+    public function testAggregateFailureWithSharedMessageAndDifferentStageRemainsIndependent(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => false,
+            'action' => 'install',
+            'stage' => 'registration',
+            'error' => 'Operation failed.',
+            'hooks' => [[
+                'ok' => false,
+                'status' => 'failed',
+                'error' => 'Operation failed.',
+            ]],
+        ]);
+
+        $this->assertSame('registration', $result['stage']);
+        $this->assertSame('addon_lifecycle_failed', $result['readiness']['reasons'][0]['code']);
+        $this->assertSame('addon_hook_failed', $result['readiness']['reasons'][1]['code']);
+    }
 }

--- a/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
@@ -82,6 +82,31 @@ final class AddOnLifecycleReadinessServiceTest extends TestCase
         $this->assertSame('addon_hook_failed', $result['readiness']['reasons'][0]['code']);
     }
 
+    public function testOptionalHookDoesNotHideAnIndependentLifecycleFailure(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => false,
+            'action' => 'install',
+            'addon' => 'sample',
+            'changed' => false,
+            'stage' => 'registration',
+            'error' => 'Registration factory failed.',
+            'hooks' => [[
+                'ok' => false,
+                'hook' => 'install',
+                'status' => 'missing_callable',
+                'error' => 'No compatible lifecycle hook callable was found.',
+            ]],
+            'migrations' => ['ok' => true],
+            'population' => ['ok' => true],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('registration', $result['stage']);
+        $this->assertSame('Registration factory failed.', $result['error']);
+        $this->assertSame('addon_lifecycle_failed', $result['readiness']['reasons'][0]['code']);
+    }
+
     public function testBatchCountsAreRecomputedFromNormalizedChildren(): void
     {
         $result = (new AddOnLifecycleReadinessService())->normalize([
@@ -121,5 +146,37 @@ final class AddOnLifecycleReadinessServiceTest extends TestCase
         $this->assertSame('blocked', $result['readiness']['state']);
         $this->assertFalse($result['results'][1]['ok']);
         $this->assertSame('retry_lifecycle', $result['nextAction']);
+    }
+
+    public function testRecoveredOptionalHookBatchClearsFailureMetadata(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => false,
+            'action' => 'install_all',
+            'stage' => 'hook',
+            'error' => 'A child failed.',
+            'nextAction' => 'retry_lifecycle',
+            'results' => [[
+                'ok' => false,
+                'action' => 'install',
+                'addon' => 'sample',
+                'changed' => true,
+                'stage' => 'complete',
+                'hooks' => [[
+                    'ok' => false,
+                    'hook' => 'install',
+                    'status' => 'missing_callable',
+                    'error' => 'No compatible lifecycle hook callable was found.',
+                ]],
+                'migrations' => ['ok' => true],
+                'population' => ['ok' => true],
+            ]],
+        ]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame('complete', $result['stage']);
+        $this->assertNull($result['error']);
+        $this->assertSame('activate_all', $result['nextAction']);
+        $this->assertSame('ready', $result['readiness']['state']);
     }
 }

--- a/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
@@ -39,8 +39,8 @@ final class AddOnLifecycleReadinessServiceTest extends TestCase
             'ok' => false,
             'action' => 'install',
             'stage' => 'migrations',
-            'error' => '',
-            'migrations' => ['ok' => false, 'error' => ''],
+            'error' => '   ',
+            'migrations' => ['ok' => false, 'error' => " \t "],
             'population' => ['ok' => true],
             'hooks' => [],
         ]);

--- a/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
@@ -107,6 +107,54 @@ final class AddOnLifecycleReadinessServiceTest extends TestCase
         $this->assertSame('addon_lifecycle_failed', $result['readiness']['reasons'][0]['code']);
     }
 
+    public function testRequiredHookDoesNotHideAnIndependentAggregateFailure(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => false,
+            'action' => 'install',
+            'addon' => 'sample',
+            'changed' => false,
+            'stage' => 'registration',
+            'error' => 'Registration factory failed.',
+            'hooks' => [[
+                'ok' => false,
+                'hook' => 'install',
+                'status' => 'failed',
+                'error' => 'Required hook failed.',
+            ]],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('registration', $result['stage']);
+        $this->assertSame('addon_lifecycle_failed', $result['readiness']['reasons'][0]['code']);
+        $this->assertSame('addon_hook_failed', $result['readiness']['reasons'][1]['code']);
+    }
+
+    public function testRecoveredSingleHookClearsFailureMetadata(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => false,
+            'action' => 'install',
+            'addon' => 'sample',
+            'changed' => true,
+            'stage' => 'hook',
+            'nextAction' => 'retry_lifecycle',
+            'hooks' => [[
+                'ok' => false,
+                'hook' => 'install',
+                'status' => 'missing_callable',
+                'error' => 'No compatible lifecycle hook callable was found.',
+            ]],
+            'migrations' => ['ok' => true],
+            'population' => ['ok' => true],
+        ]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame('complete', $result['stage']);
+        $this->assertSame('activate', $result['nextAction']);
+        $this->assertNull($result['error']);
+    }
+
     public function testBatchCountsAreRecomputedFromNormalizedChildren(): void
     {
         $result = (new AddOnLifecycleReadinessService())->normalize([

--- a/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
@@ -328,4 +328,25 @@ final class AddOnLifecycleReadinessServiceTest extends TestCase
         $this->assertSame('Schema failed.', $result['error']);
         $this->assertCount(1, $result['readiness']['reasons']);
     }
+
+    public function testRecoveredOptionalHookBatchMayOmitTheAggregateStage(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => false,
+            'action' => 'install_all',
+            'results' => [[
+                'ok' => false,
+                'action' => 'install',
+                'hooks' => [[
+                    'ok' => false,
+                    'status' => 'missing_callable',
+                ]],
+            ]],
+        ]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame('complete', $result['stage']);
+        $this->assertNull($result['error']);
+        $this->assertSame('ready', $result['readiness']['state']);
+    }
 }

--- a/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
@@ -155,6 +155,26 @@ final class AddOnLifecycleReadinessServiceTest extends TestCase
         $this->assertNull($result['error']);
     }
 
+    public function testMultipleRequiredFailuresKeepTheSelectedStageAndErrorAligned(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => false,
+            'action' => 'install',
+            'addon' => 'sample',
+            'changed' => true,
+            'stage' => 'population',
+            'error' => 'Population failed.',
+            'hooks' => [],
+            'migrations' => ['ok' => false, 'error' => 'Migration failed.'],
+            'population' => ['ok' => false, 'error' => 'Population failed.'],
+        ]);
+
+        $this->assertSame('population', $result['stage']);
+        $this->assertSame('Population failed.', $result['error']);
+        $this->assertSame('addon_migration_failed', $result['readiness']['reasons'][0]['code']);
+        $this->assertSame('addon_population_failed', $result['readiness']['reasons'][1]['code']);
+    }
+
     public function testBatchCountsAreRecomputedFromNormalizedChildren(): void
     {
         $result = (new AddOnLifecycleReadinessService())->normalize([

--- a/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
@@ -285,4 +285,47 @@ final class AddOnLifecycleReadinessServiceTest extends TestCase
         $this->assertSame('addon_lifecycle_failed', $result['readiness']['reasons'][0]['code']);
         $this->assertSame('addon_hook_failed', $result['readiness']['reasons'][1]['code']);
     }
+
+    public function testIndependentDiscoveryFailureSurvivesOptionalChildRecovery(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => false,
+            'action' => 'install_all',
+            'stage' => 'discovery',
+            'error' => 'Discovery failed.',
+            'results' => [[
+                'ok' => false,
+                'action' => 'install',
+                'stage' => 'hook',
+                'hooks' => [[
+                    'ok' => false,
+                    'status' => 'missing_callable',
+                    'error' => 'No lifecycle hook.',
+                ]],
+            ]],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('discovery', $result['stage']);
+        $this->assertSame('Discovery failed.', $result['error']);
+    }
+
+    public function testBatchWithoutAggregateErrorUsesTheMatchingChildFailure(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => false,
+            'action' => 'install_all',
+            'stage' => 'migrations',
+            'results' => [[
+                'ok' => false,
+                'action' => 'install',
+                'stage' => 'migrations',
+                'migrations' => ['ok' => false, 'error' => 'Schema failed.'],
+            ]],
+        ]);
+
+        $this->assertSame('migrations', $result['stage']);
+        $this->assertSame('Schema failed.', $result['error']);
+        $this->assertCount(1, $result['readiness']['reasons']);
+    }
 }

--- a/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Business\Services;
+
+use App\Business\Services\AddOnLifecycleReadinessService;
+use PHPUnit\Framework\TestCase;
+
+final class AddOnLifecycleReadinessServiceTest extends TestCase
+{
+    public function testRequiredDatasourceFailureOverridesOptimisticLifecycleStatus(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => true,
+            'action' => 'install',
+            'addon' => 'sample',
+            'changed' => true,
+            'stage' => 'complete',
+            'hooks' => [],
+            'migrations' => [
+                'ok' => false,
+                'error' => 'Required schema could not be applied.',
+            ],
+            'population' => ['ok' => true],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('migrations', $result['stage']);
+        $this->assertSame('blocked', $result['readiness']['state']);
+        $this->assertSame('addon_migration_failed', $result['readiness']['reasons'][0]['code']);
+    }
+
+    public function testAbsentOptionalHookIsReportedAsSkippedWithoutContradictingSuccess(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => true,
+            'action' => 'install',
+            'addon' => 'sample',
+            'changed' => true,
+            'stage' => 'complete',
+            'hooks' => [[
+                'ok' => false,
+                'hook' => 'install',
+                'status' => 'missing_callable',
+                'error' => 'No compatible lifecycle hook callable was found.',
+            ]],
+            'migrations' => ['ok' => true],
+            'population' => ['ok' => true],
+        ]);
+
+        $this->assertTrue($result['ok']);
+        $this->assertSame('ready', $result['readiness']['state']);
+        $this->assertTrue($result['hooks'][0]['optional']);
+        $this->assertSame('skipped', $result['hooks'][0]['status']);
+        $this->assertSame('lifecycle_hook_not_declared', $result['hooks'][0]['reason']);
+        $this->assertNull($result['hooks'][0]['error']);
+    }
+
+    public function testRequiredHookResolutionFailureBlocksLifecycleReadiness(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => true,
+            'action' => 'install',
+            'addon' => 'sample',
+            'changed' => false,
+            'stage' => 'complete',
+            'hooks' => [[
+                'ok' => false,
+                'hook' => 'install',
+                'status' => 'missing_primary_file',
+                'error' => 'Primary file could not be resolved.',
+            ]],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('hook', $result['stage']);
+        $this->assertSame('addon_hook_failed', $result['readiness']['reasons'][0]['code']);
+    }
+
+    public function testBatchCountsAreRecomputedFromNormalizedChildren(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => true,
+            'action' => 'install_all',
+            'total' => 2,
+            'succeeded' => 2,
+            'failed' => 0,
+            'results' => [
+                [
+                    'ok' => true,
+                    'action' => 'install',
+                    'addon' => 'first',
+                    'changed' => true,
+                    'hooks' => [],
+                    'migrations' => ['ok' => true],
+                    'population' => ['ok' => true],
+                ],
+                [
+                    'ok' => true,
+                    'action' => 'install',
+                    'addon' => 'second',
+                    'changed' => false,
+                    'hooks' => [],
+                    'migrations' => ['ok' => false, 'error' => 'Migration failed.'],
+                    'population' => [],
+                ],
+            ],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame(2, $result['total']);
+        $this->assertSame(1, $result['succeeded']);
+        $this->assertSame(1, $result['failed']);
+        $this->assertTrue($result['changed']);
+        $this->assertSame('blocked', $result['readiness']['state']);
+        $this->assertFalse($result['results'][1]['ok']);
+    }
+}

--- a/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
@@ -414,11 +414,48 @@ final class AddOnLifecycleReadinessServiceTest extends TestCase
         $this->assertCount(2, $result['readiness']['reasons']);
     }
 
+    public function testTerminalSingleAggregateErrorSelectsItsMatchingChildFailure(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => false,
+            'action' => 'install',
+            'stage' => 'complete',
+            'error' => 'Population failed.',
+            'migrations' => ['ok' => false, 'error' => 'Schema failed.'],
+            'population' => ['ok' => false, 'error' => 'Population failed.'],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('population', $result['stage']);
+        $this->assertSame('Population failed.', $result['error']);
+        $this->assertCount(2, $result['readiness']['reasons']);
+    }
+
     public function testUnstagedBatchAggregateErrorMatchesItsChildFailure(): void
     {
         $result = (new AddOnLifecycleReadinessService())->normalize([
             'ok' => false,
             'action' => 'install_all',
+            'error' => 'Population failed.',
+            'results' => [[
+                'ok' => false,
+                'action' => 'install',
+                'population' => ['ok' => false, 'error' => 'Population failed.'],
+            ]],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('population', $result['stage']);
+        $this->assertSame('Population failed.', $result['error']);
+        $this->assertCount(1, $result['readiness']['reasons']);
+    }
+
+    public function testTerminalBatchAggregateErrorMatchesItsChildFailure(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => false,
+            'action' => 'install_all',
+            'stage' => 'complete',
             'error' => 'Population failed.',
             'results' => [[
                 'ok' => false,

--- a/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
@@ -193,6 +193,8 @@ final class AddOnLifecycleReadinessServiceTest extends TestCase
         $this->assertTrue($result['changed']);
         $this->assertSame('blocked', $result['readiness']['state']);
         $this->assertFalse($result['results'][1]['ok']);
+        $this->assertSame('migrations', $result['stage']);
+        $this->assertSame('Migration failed.', $result['error']);
         $this->assertSame('retry_lifecycle', $result['nextAction']);
     }
 

--- a/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
@@ -33,6 +33,24 @@ final class AddOnLifecycleReadinessServiceTest extends TestCase
         $this->assertSame('retry_lifecycle', $result['nextAction']);
     }
 
+    public function testBlankRequiredStageErrorUsesTheStageFallback(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => false,
+            'action' => 'install',
+            'stage' => 'migrations',
+            'error' => '',
+            'migrations' => ['ok' => false, 'error' => ''],
+            'population' => ['ok' => true],
+            'hooks' => [],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('migrations', $result['stage']);
+        $this->assertSame('Add-on migrations failed.', $result['error']);
+        $this->assertSame('Add-on migrations failed.', $result['readiness']['reasons'][0]['message']);
+    }
+
     public function testAbsentOptionalHookIsReportedAsSkippedWithoutContradictingSuccess(): void
     {
         $result = (new AddOnLifecycleReadinessService())->normalize([

--- a/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
@@ -382,4 +382,39 @@ final class AddOnLifecycleReadinessServiceTest extends TestCase
         $this->assertSame('Schema failed.', $result['error']);
         $this->assertCount(1, $result['readiness']['reasons']);
     }
+
+    public function testUnstagedSingleAggregateErrorMatchesItsChildFailure(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => false,
+            'action' => 'install',
+            'error' => 'Schema failed.',
+            'migrations' => ['ok' => false, 'error' => 'Schema failed.'],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('migrations', $result['stage']);
+        $this->assertSame('Schema failed.', $result['error']);
+        $this->assertCount(1, $result['readiness']['reasons']);
+    }
+
+    public function testTerminalBatchStageUsesItsActionableChildFailure(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => false,
+            'action' => 'install_all',
+            'stage' => 'complete',
+            'results' => [[
+                'ok' => false,
+                'action' => 'install',
+                'stage' => 'population',
+                'population' => ['ok' => false, 'error' => 'Population failed.'],
+            ]],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('population', $result['stage']);
+        $this->assertSame('Population failed.', $result['error']);
+        $this->assertCount(1, $result['readiness']['reasons']);
+    }
 }

--- a/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
+++ b/tests/Unit/Business/Services/AddOnLifecycleReadinessServiceTest.php
@@ -349,4 +349,23 @@ final class AddOnLifecycleReadinessServiceTest extends TestCase
         $this->assertNull($result['error']);
         $this->assertSame('ready', $result['readiness']['state']);
     }
+
+    public function testUnstagedBatchUsesItsActionableChildFailure(): void
+    {
+        $result = (new AddOnLifecycleReadinessService())->normalize([
+            'ok' => false,
+            'action' => 'install_all',
+            'results' => [[
+                'ok' => false,
+                'action' => 'install',
+                'stage' => 'migrations',
+                'migrations' => ['ok' => false, 'error' => 'Schema failed.'],
+            ]],
+        ]);
+
+        $this->assertFalse($result['ok']);
+        $this->assertSame('migrations', $result['stage']);
+        $this->assertSame('Schema failed.', $result['error']);
+        $this->assertCount(1, $result['readiness']['reasons']);
+    }
 }


### PR DESCRIPTION
## Intent

Make Opus add-on lifecycle results structurally truthful across command and administrative API surfaces.

Related to #12. This PR does not close the issue until the released lifecycle manager supplies structured datasource outcomes and fresh-database acceptance passes.

## User stories and acceptance criteria

- Required migration, population, primary-file, and declared-hook failures block readiness.
- Missing optional lifecycle callables are represented as `skipped` and `optional`, not contradictory failed hooks.
- Aggregate failures caused only by absent optional hooks are recomputed as ready.
- Independent aggregate failures remain visible even when a required hook also fails.
- Recovered single and batch outcomes replace stale failure stage and retry guidance.
- Blocking results replace stale success guidance with `retry_lifecycle`.
- Batch `total`, `succeeded`, and `failed` counters are recomputed from normalized children.
- CLI commands preserve exact case-sensitive add-on identifiers and return structured arrays instead of interpolating arrays into terminal strings.
- Administrative install, uninstall, and activation responses use the same normalizer.
- Stable readiness states and reason codes are available to Wise and other programmatic callers.
- Human-readable migration or generator output is never parsed to infer success.

## Key files

- `app/Business/Services/AddOnLifecycleReadinessService.php`
- `app/Business/Console/AddOnManager.php`
- `app/Business/Http/Api/Admin/AddOnController.php`
- `mapping/console.php`
- `ADDONS.md`

## Validation

```text
Focused lifecycle and console contracts: 11 tests, 52 assertions
Broader repository suite: 122 tests, 640 assertions, 3 expected platform skips
PHP syntax checks: pass
git diff --check: pass
```

The broader local run excluded `TemplateHelperIntegrationTest` because the shared host vendor checkout predates the locked BlueCore helper implementation. Clean-install CI must run that dependency-coupled test before approval. The existing Windows link diagnostic remains an expected platform limitation.

## QA checklist

- [x] Optimistic parent status cannot hide a structured required-stage failure.
- [x] Optional absent hooks do not fail an otherwise valid result.
- [x] Required hook resolution failures remain blocking.
- [x] Failure recovery guidance cannot retain `activate` or `activate_all`.
- [x] Batch counters, stage, and error derive from normalized child results.
- [x] Independent aggregate and required-hook failures are both retained.
- [x] Recovered single outcomes report complete stage and activation guidance.
- [x] CLI and API lifecycle surfaces share one readiness contract.
- [ ] Clean-install CI passes the complete suite.
- [ ] Released upstream datasource results are consumed and verified against fresh MySQL.
- [ ] Independent review confirms reason codes and backward compatibility.

## Approval conditions

Approve this host-boundary slice after clean-install CI and independent review. Keep #12 open until the upstream lifecycle release lands and fresh MySQL proves that required migration and generator failures produce `ok=false` end to end.
