### PR TITLE
Normalize code command results

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -78,6 +78,9 @@ Acceptance criteria:
 - Console managers expose small, testable operations that Wise can call.
 - Script execution routes through Wise bridges rather than bespoke Opus
   interpreters.
+- Backend generation commands return structured operation, status, exit-code,
+  output, and diagnostic data without writing directly to terminal streams.
+  The invoking host owns presentation and process termination.
 
 ### Agent Orchestration
 

--- a/app/Business/Console/CodeManager.php
+++ b/app/Business/Console/CodeManager.php
@@ -22,51 +22,37 @@ class CodeManager extends Service
 
     public function generate(string $type, string $name, string $prompt): array
     {
-        print "Please wait...\n";
-        $result = Arr::make($this->generationService->renderSource($prompt, [
+        return $this->result('generate', $this->generationService->renderSource($prompt, [
             'type' => $type,
             'name' => $name,
         ]));
-
-        if ($result->get('valid')) {
-            if ($result->get('output') !== '') {
-                print $result->get('output') . "\n";
-            }
-            print "Generation completed.\n";
-        } else {
-            print $this->formatErrors(Arr::make($result->get('errors'))->val());
-        }
-
-        return $result->val();
     }
 
     public function render(string $source, array $variables = []): array
     {
-        return $this->generationService->renderSource($source, $variables);
+        return $this->result('render', $this->generationService->renderSource($source, $variables));
     }
 
     public function renderFile(string $sourcePath, ?string $outputPath = null, array $variables = []): array
     {
         if (Str::isNotEmpty($outputPath)) {
-            return $this->generationService->writeRenderedFile($sourcePath, $outputPath, $variables);
+            return $this->result(
+                'render_file',
+                $this->generationService->writeRenderedFile($sourcePath, $outputPath, $variables)
+            );
         }
 
-        return $this->generationService->renderFile($sourcePath, $variables);
+        return $this->result('render_file', $this->generationService->renderFile($sourcePath, $variables));
     }
 
-    private function formatErrors(array $errors): string
+    private function result(string $operation, array $result): array
     {
-        $errors = Arr::make($errors);
-        if ($errors->isEmpty()) {
-            return "Generation failed.\n";
-        }
+        $result = Arr::make($result);
+        $valid = (bool) $result->get('valid');
+        $result->set('operation', $operation);
+        $result->set('status', $valid ? 'completed' : 'failed');
+        $result->set('exit_code', $valid ? 0 : 1);
 
-        $lines = Arr::make(["Generation failed:"]);
-        foreach ($errors as $error) {
-            $error = Arr::make($error);
-            $lines->push('- ' . ($error->get('message') ?? 'Unknown error'));
-        }
-
-        return $lines->join("\n")->append("\n")->val();
+        return $result->toArray();
     }
 }

--- a/tests/Unit/Business/Console/CodeManagerTest.php
+++ b/tests/Unit/Business/Console/CodeManagerTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class CodeManagerTest extends TestCase
 {
-    public function testGenerateReturnsResultAndPrintsRenderedOutput(): void
+    public function testGenerateReturnsAHostNeutralCompletedResult(): void
     {
         $service = new class extends VibeGenerationService {
             public function renderSource(
@@ -34,12 +34,14 @@ class CodeManagerTest extends TestCase
         $output = (string) ob_get_clean();
 
         $this->assertTrue($result['valid']);
+        $this->assertSame('generate', $result['operation']);
+        $this->assertSame('completed', $result['status']);
+        $this->assertSame(0, $result['exit_code']);
         $this->assertSame('Generated service Example', $result['output']);
-        $this->assertStringContainsString('Generated service Example', $output);
-        $this->assertStringContainsString('Generation completed.', $output);
+        $this->assertSame('', $output);
     }
 
-    public function testGeneratePrintsStructuredValidationErrors(): void
+    public function testGenerateReturnsAHostNeutralFailureResult(): void
     {
         $service = new class extends VibeGenerationService {
             public function renderSource(
@@ -65,7 +67,37 @@ class CodeManagerTest extends TestCase
         $output = (string) ob_get_clean();
 
         $this->assertFalse($result['valid']);
-        $this->assertStringContainsString('Generation failed:', $output);
-        $this->assertStringContainsString('- Template is invalid.', $output);
+        $this->assertSame('generate', $result['operation']);
+        $this->assertSame('failed', $result['status']);
+        $this->assertSame(1, $result['exit_code']);
+        $this->assertSame([['message' => 'Template is invalid.']], $result['errors']);
+        $this->assertSame('', $output);
+    }
+
+    public function testRenderUsesTheSameOperationResultContract(): void
+    {
+        $service = new class extends VibeGenerationService {
+            public function renderSource(
+                string $source,
+                array $variables = [],
+                array $includePaths = [],
+                array $options = []
+            ): array {
+                return [
+                    'valid' => true,
+                    'errors' => [],
+                    'output' => $source,
+                    'variables' => $variables,
+                ];
+            }
+        };
+
+        $result = (new CodeManager($service))->render('ready', ['scope' => 'test']);
+
+        $this->assertSame('render', $result['operation']);
+        $this->assertSame('completed', $result['status']);
+        $this->assertSame(0, $result['exit_code']);
+        $this->assertSame('ready', $result['output']);
+        $this->assertSame(['scope' => 'test'], $result['variables']);
     }
 }


### PR DESCRIPTION
## Intent

Normalize the code-generation console boundary so execution returns structured data and leaves presentation and process termination to the invoking host.

Related to #13.

## User Stories / Acceptance Criteria

- Generation, source rendering, and file rendering return the same operation result fields.
- Existing `valid`, `errors`, `output`, `variables`, and optional `path` fields remain compatible.
- Results add stable `operation`, `status`, and `exit_code` fields.
- The manager does not print progress, generated output, or validation messages.
- Wise, CLI, HTTP, and agent hosts can render the same result without capturing terminal output.

## Key Files

- `app/Business/Console/CodeManager.php`
- `tests/Unit/Business/Console/CodeManagerTest.php`
- `SPEC.md`

## Validation

```text
phpunit tests/Unit/Business/Console/CodeManagerTest.php
3 tests, 17 assertions

phpunit broad suite excluding the separately verified template-helper integration test
116 tests, 617 assertions, 3 expected skips

composer validate --no-check-publish
valid with the existing non-SPDX license warning
```

The broad suite also emits the already tracked non-failing Windows `link()` shutdown diagnostic.

## QA Checklist

- [x] Existing generation payload fields are preserved.
- [x] Success and failure exit codes are deterministic.
- [x] No terminal output is emitted by the manager.
- [x] DevElation `Arr` owns result normalization.
- [x] No dependency or environment changes are required.

## Approval Conditions

- Confirm terminal presentation remains a host concern.
- Confirm the compatible additive result fields are suitable for the remaining console-manager migration.
- Keep #13 open for destructive command policy, inventory, migration notes, and other manager groups.
