### PR TITLE
Add resumable application intake sessions

### DIFF
--- a/app/Business/Services/ApplicationIntakeService.php
+++ b/app/Business/Services/ApplicationIntakeService.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Business\Services;
+
+use App\Domain\Onboarding\ApplicationIntakeSession;
+use App\Domain\Onboarding\IApplicationIntakeRepository;
+use RuntimeException;
+
+final class ApplicationIntakeService
+{
+    public function __construct(private IApplicationIntakeRepository $repository)
+    {
+    }
+
+    public function start(
+        string $projectName,
+        ?string $tenantId = null,
+        ?string $applicationSlug = null,
+        string $promptVersion = ApplicationIntakeSession::VERSION,
+        array $actor = [],
+        ?string $correlationId = null
+    ): ApplicationIntakeSession {
+        $candidate = ApplicationIntakeSession::start(
+            $projectName,
+            $tenantId,
+            $applicationSlug,
+            $promptVersion,
+            $actor,
+            $correlationId
+        );
+        $existing = $this->repository->find($candidate->sessionId());
+        if (
+            $existing !== null
+            && $existing->answers()['project_name'] !== $candidate->answers()['project_name']
+        ) {
+            throw new RuntimeException('application_slug_conflict');
+        }
+
+        return $existing ?? $this->repository->save($candidate);
+    }
+
+    public function find(string $sessionId): ?ApplicationIntakeSession
+    {
+        return $this->repository->find($sessionId);
+    }
+
+    public function answer(
+        string $sessionId,
+        string $field,
+        mixed $value,
+        array $actor = [],
+        ?string $correlationId = null
+    ): ApplicationIntakeSession {
+        return $this->repository->save(
+            $this->requireSession($sessionId)->answer($field, $value, $actor, $correlationId)
+        );
+    }
+
+    public function skip(
+        string $sessionId,
+        string $field,
+        array $actor = [],
+        ?string $correlationId = null
+    ): ApplicationIntakeSession {
+        return $this->repository->save(
+            $this->requireSession($sessionId)->skip($field, $actor, $correlationId)
+        );
+    }
+
+    public function pause(
+        string $sessionId,
+        array $actor = [],
+        ?string $correlationId = null
+    ): ApplicationIntakeSession {
+        return $this->repository->save(
+            $this->requireSession($sessionId)->pause($actor, $correlationId)
+        );
+    }
+
+    public function resume(
+        string $sessionId,
+        array $actor = [],
+        ?string $correlationId = null
+    ): ApplicationIntakeSession {
+        return $this->repository->save(
+            $this->requireSession($sessionId)->resume($actor, $correlationId)
+        );
+    }
+
+    public function complete(
+        string $sessionId,
+        array $actor = [],
+        ?string $correlationId = null
+    ): ApplicationIntakeSession {
+        return $this->repository->save(
+            $this->requireSession($sessionId)->complete($actor, $correlationId)
+        );
+    }
+
+    private function requireSession(string $sessionId): ApplicationIntakeSession
+    {
+        $session = $this->repository->find($sessionId);
+        if ($session === null) {
+            throw new RuntimeException('intake_session_not_found');
+        }
+
+        return $session;
+    }
+}

--- a/app/Business/Services/ApplicationIntakeService.php
+++ b/app/Business/Services/ApplicationIntakeService.php
@@ -38,7 +38,27 @@ final class ApplicationIntakeService
             throw new RuntimeException('application_slug_conflict');
         }
 
-        return $existing ?? $this->repository->save($candidate);
+        if ($existing !== null) {
+            return $existing;
+        }
+
+        try {
+            return $this->repository->save($candidate);
+        } catch (RuntimeException $exception) {
+            if ($exception->getMessage() !== 'intake_session_already_exists') {
+                throw $exception;
+            }
+
+            $existing = $this->repository->find($candidate->sessionId());
+            if ($existing === null) {
+                throw $exception;
+            }
+            if ($existing->answers()['project_name'] !== $candidate->answers()['project_name']) {
+                throw new RuntimeException('application_slug_conflict');
+            }
+
+            return $existing;
+        }
     }
 
     public function find(string $sessionId): ?ApplicationIntakeSession

--- a/app/Business/Services/ApplicationIntakeService.php
+++ b/app/Business/Services/ApplicationIntakeService.php
@@ -6,6 +6,8 @@ namespace App\Business\Services;
 
 use App\Domain\Onboarding\ApplicationIntakeSession;
 use App\Domain\Onboarding\IApplicationIntakeRepository;
+use BlueFission\Arr;
+use BlueFission\DevElation;
 use RuntimeException;
 
 final class ApplicationIntakeService
@@ -22,13 +24,27 @@ final class ApplicationIntakeService
         array $actor = [],
         ?string $correlationId = null
     ): ApplicationIntakeSession {
+        $filtered = DevElation::apply('opus.intake.defaults', [
+            'defaults' => ApplicationIntakeSession::defaultValues(),
+            'context' => [
+                'project_name' => $projectName,
+                'tenant_id' => $tenantId,
+                'application_slug' => $applicationSlug,
+                'prompt_version' => $promptVersion,
+            ],
+        ]);
+        $defaults = Arr::is($filtered) && Arr::is($filtered['defaults'] ?? null)
+            ? Arr::toArray($filtered['defaults'], true)
+            : ApplicationIntakeSession::defaultValues();
+
         $candidate = ApplicationIntakeSession::start(
             $projectName,
             $tenantId,
             $applicationSlug,
             $promptVersion,
             $actor,
-            $correlationId
+            $correlationId,
+            $defaults
         );
         $existing = $this->repository->find($candidate->sessionId());
         if (
@@ -43,7 +59,7 @@ final class ApplicationIntakeService
         }
 
         try {
-            return $this->repository->save($candidate);
+            return $this->persistTransition('started', $candidate);
         } catch (RuntimeException $exception) {
             if ($exception->getMessage() !== 'intake_session_already_exists') {
                 throw $exception;
@@ -73,7 +89,8 @@ final class ApplicationIntakeService
         array $actor = [],
         ?string $correlationId = null
     ): ApplicationIntakeSession {
-        return $this->repository->save(
+        return $this->persistTransition(
+            'answered',
             $this->requireSession($sessionId)->answer($field, $value, $actor, $correlationId)
         );
     }
@@ -84,7 +101,8 @@ final class ApplicationIntakeService
         array $actor = [],
         ?string $correlationId = null
     ): ApplicationIntakeSession {
-        return $this->repository->save(
+        return $this->persistTransition(
+            'skipped',
             $this->requireSession($sessionId)->skip($field, $actor, $correlationId)
         );
     }
@@ -94,7 +112,8 @@ final class ApplicationIntakeService
         array $actor = [],
         ?string $correlationId = null
     ): ApplicationIntakeSession {
-        return $this->repository->save(
+        return $this->persistTransition(
+            'paused',
             $this->requireSession($sessionId)->pause($actor, $correlationId)
         );
     }
@@ -104,7 +123,8 @@ final class ApplicationIntakeService
         array $actor = [],
         ?string $correlationId = null
     ): ApplicationIntakeSession {
-        return $this->repository->save(
+        return $this->persistTransition(
+            'resumed',
             $this->requireSession($sessionId)->resume($actor, $correlationId)
         );
     }
@@ -114,7 +134,8 @@ final class ApplicationIntakeService
         array $actor = [],
         ?string $correlationId = null
     ): ApplicationIntakeSession {
-        return $this->repository->save(
+        return $this->persistTransition(
+            'completed',
             $this->requireSession($sessionId)->complete($actor, $correlationId)
         );
     }
@@ -127,5 +148,19 @@ final class ApplicationIntakeService
         }
 
         return $session;
+    }
+
+    private function persistTransition(
+        string $transition,
+        ApplicationIntakeSession $session
+    ): ApplicationIntakeSession {
+        $saved = $this->repository->save($session);
+
+        DevElation::do('opus.intake.session.transitioned', [[
+            'transition' => $transition,
+            'session' => $saved->toArray(),
+        ]]);
+
+        return $saved;
     }
 }

--- a/app/Domain/Onboarding/ApplicationIntakeSession.php
+++ b/app/Domain/Onboarding/ApplicationIntakeSession.php
@@ -8,7 +8,6 @@ use BlueFission\Arr;
 use BlueFission\Date;
 use BlueFission\Security\Hash;
 use BlueFission\Str;
-use BlueFission\Val;
 use InvalidArgumentException;
 
 final class ApplicationIntakeSession
@@ -144,8 +143,15 @@ final class ApplicationIntakeSession
     public function answer(string $field, mixed $value, array $actor = [], ?string $correlationId = null): self
     {
         $this->guardField($field);
-        if ($field === 'project_name' && Val::isEmpty($value)) {
-            throw new InvalidArgumentException('project_name_required');
+        if ($field === 'project_name') {
+            if (!Str::is($value)) {
+                throw new InvalidArgumentException('project_name_required');
+            }
+
+            $value = Str::make($value)->trim()->val();
+            if (Str::isEmpty($value)) {
+                throw new InvalidArgumentException('project_name_required');
+            }
         }
 
         $answers = $this->answers->toArray();
@@ -327,7 +333,8 @@ final class ApplicationIntakeSession
         if (!Arr::make([self::IN_PROGRESS, self::PAUSED, self::COMPLETED])->contains($this->status())) {
             throw new InvalidArgumentException('invalid_intake_status');
         }
-        if (Val::isEmpty($this->answers->toArray()['project_name'] ?? null)) {
+        $projectName = $this->answers->toArray()['project_name'] ?? null;
+        if (!Str::is($projectName) || Str::isEmpty(Str::make($projectName)->trim()->val())) {
             throw new InvalidArgumentException('project_name_required');
         }
     }

--- a/app/Domain/Onboarding/ApplicationIntakeSession.php
+++ b/app/Domain/Onboarding/ApplicationIntakeSession.php
@@ -89,7 +89,8 @@ final class ApplicationIntakeSession
         ?string $applicationSlug = null,
         string $promptVersion = self::VERSION,
         array $actor = [],
-        ?string $correlationId = null
+        ?string $correlationId = null,
+        ?array $defaults = null
     ): self {
         $projectName = Str::make($projectName)->trim()->val();
         if (Str::isEmpty($projectName)) {
@@ -110,7 +111,7 @@ final class ApplicationIntakeSession
             $promptVersion,
             self::IN_PROGRESS,
             ['project_name' => $projectName],
-            self::defaultAnswers(),
+            $defaults ?? self::defaultValues(),
             [],
             $actor,
             $correlationId,
@@ -129,7 +130,7 @@ final class ApplicationIntakeSession
             (string) ($data['prompt_version'] ?? self::VERSION),
             (string) ($data['status'] ?? self::IN_PROGRESS),
             Arr::toArray($data['answers'] ?? [], true),
-            Arr::toArray($data['defaults'] ?? self::defaultAnswers(), true),
+            Arr::toArray($data['defaults'] ?? self::defaultValues(), true),
             Arr::toArray($data['skipped'] ?? [], true),
             Arr::toArray($data['actor'] ?? [], true),
             $data['correlation_id'] ?? null,
@@ -292,7 +293,7 @@ final class ApplicationIntakeSession
         ];
     }
 
-    private static function defaultAnswers(): array
+    public static function defaultValues(): array
     {
         return [
             'project_type' => 'general_web_application',

--- a/app/Domain/Onboarding/ApplicationIntakeSession.php
+++ b/app/Domain/Onboarding/ApplicationIntakeSession.php
@@ -1,0 +1,374 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Onboarding;
+
+use BlueFission\Arr;
+use BlueFission\Date;
+use BlueFission\Security\Hash;
+use BlueFission\Str;
+use BlueFission\Val;
+use InvalidArgumentException;
+
+final class ApplicationIntakeSession
+{
+    public const VERSION = '1.0';
+    public const IN_PROGRESS = 'in_progress';
+    public const PAUSED = 'paused';
+    public const COMPLETED = 'completed';
+
+    private const FIELDS = [
+        'project_name',
+        'project_type',
+        'industry',
+        'audience',
+        'description',
+        'specification',
+        'personality',
+        'agent_name',
+        'delivery_strategy',
+        'timeline',
+    ];
+
+    private Str $sessionId;
+    private ?Str $tenantId;
+    private Str $applicationSlug;
+    private Str $promptVersion;
+    private Str $status;
+    private Arr $answers;
+    private Arr $defaults;
+    private Arr $skipped;
+    private Arr $actor;
+    private ?Str $correlationId;
+    private int $revision;
+    private Str $createdAt;
+    private Str $updatedAt;
+    private ?Str $completedAt;
+
+    public function __construct(
+        string $sessionId,
+        ?string $tenantId,
+        string $applicationSlug,
+        string $promptVersion,
+        string $status,
+        array $answers,
+        array $defaults,
+        array $skipped,
+        array $actor,
+        ?string $correlationId,
+        int $revision,
+        string $createdAt,
+        string $updatedAt,
+        ?string $completedAt = null
+    ) {
+        $this->sessionId = Str::make($sessionId);
+        $this->tenantId = Str::isNotEmpty((string) $tenantId) ? Str::make((string) $tenantId) : null;
+        $this->applicationSlug = Str::make($applicationSlug);
+        $this->promptVersion = Str::make($promptVersion);
+        $this->status = Str::make($status);
+        $this->answers = Arr::make($answers);
+        $this->defaults = Arr::make($defaults);
+        $this->skipped = Arr::make($skipped)->unique();
+        $this->actor = Arr::make($actor);
+        $this->correlationId = Str::isNotEmpty((string) $correlationId)
+            ? Str::make((string) $correlationId)
+            : null;
+        $this->revision = $revision;
+        $this->createdAt = Str::make($createdAt);
+        $this->updatedAt = Str::make($updatedAt);
+        $this->completedAt = Str::isNotEmpty((string) $completedAt)
+            ? Str::make((string) $completedAt)
+            : null;
+
+        $this->guard();
+    }
+
+    public static function start(
+        string $projectName,
+        ?string $tenantId = null,
+        ?string $applicationSlug = null,
+        string $promptVersion = self::VERSION,
+        array $actor = [],
+        ?string $correlationId = null
+    ): self {
+        $projectName = Str::make($projectName)->trim()->val();
+        if (Str::isEmpty($projectName)) {
+            throw new InvalidArgumentException('project_name_required');
+        }
+
+        $slug = self::normalizeSlug($applicationSlug ?? $projectName);
+        $scope = Str::isNotEmpty((string) $tenantId)
+            ? 'tenant:' . (string) $tenantId
+            : 'scope:application';
+        $sessionId = (new Hash('sha256'))->hash('opus-intake:' . $scope . ':' . $slug);
+        $now = self::now();
+
+        return new self(
+            $sessionId,
+            $tenantId,
+            $slug,
+            $promptVersion,
+            self::IN_PROGRESS,
+            ['project_name' => $projectName],
+            self::defaultAnswers(),
+            [],
+            $actor,
+            $correlationId,
+            1,
+            $now,
+            $now
+        );
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            (string) ($data['session_id'] ?? ''),
+            $data['tenant_id'] ?? null,
+            (string) ($data['application_slug'] ?? ''),
+            (string) ($data['prompt_version'] ?? self::VERSION),
+            (string) ($data['status'] ?? self::IN_PROGRESS),
+            Arr::toArray($data['answers'] ?? [], true),
+            Arr::toArray($data['defaults'] ?? self::defaultAnswers(), true),
+            Arr::toArray($data['skipped'] ?? [], true),
+            Arr::toArray($data['actor'] ?? [], true),
+            $data['correlation_id'] ?? null,
+            (int) ($data['revision'] ?? 1),
+            (string) ($data['created_at'] ?? self::now()),
+            (string) ($data['updated_at'] ?? self::now()),
+            $data['completed_at'] ?? null
+        );
+    }
+
+    public function answer(string $field, mixed $value, array $actor = [], ?string $correlationId = null): self
+    {
+        $this->guardField($field);
+        if ($field === 'project_name' && Val::isEmpty($value)) {
+            throw new InvalidArgumentException('project_name_required');
+        }
+
+        $answers = $this->answers->toArray();
+        $answers[$field] = $value;
+        $skipped = $this->skipped
+            ->filter(static fn (mixed $item): bool => $item !== $field)
+            ->toArray();
+
+        return $this->revise(
+            answers: $answers,
+            skipped: $skipped,
+            actor: $actor,
+            correlationId: $correlationId
+        );
+    }
+
+    public function skip(string $field, array $actor = [], ?string $correlationId = null): self
+    {
+        $this->guardField($field);
+        if ($field === 'project_name') {
+            throw new InvalidArgumentException('project_name_required');
+        }
+
+        $answers = $this->answers
+            ->filter(static fn (mixed $value, mixed $key): bool => $key !== $field)
+            ->toArray();
+        $skipped = Arr::make(Arr::merge($this->skipped->toArray(), [$field]))
+            ->unique()
+            ->toArray();
+
+        return $this->revise(
+            answers: $answers,
+            skipped: $skipped,
+            actor: $actor,
+            correlationId: $correlationId
+        );
+    }
+
+    public function pause(array $actor = [], ?string $correlationId = null): self
+    {
+        return $this->revise(status: self::PAUSED, actor: $actor, correlationId: $correlationId);
+    }
+
+    public function resume(array $actor = [], ?string $correlationId = null): self
+    {
+        return $this->revise(
+            status: self::IN_PROGRESS,
+            actor: $actor,
+            correlationId: $correlationId,
+            completedAt: null
+        );
+    }
+
+    public function complete(array $actor = [], ?string $correlationId = null): self
+    {
+        return $this->revise(
+            status: self::COMPLETED,
+            actor: $actor,
+            correlationId: $correlationId,
+            completedAt: self::now()
+        );
+    }
+
+    public function sessionId(): string
+    {
+        return $this->sessionId->val();
+    }
+
+    public function tenantId(): ?string
+    {
+        return $this->tenantId?->val();
+    }
+
+    public function applicationSlug(): string
+    {
+        return $this->applicationSlug->val();
+    }
+
+    public function status(): string
+    {
+        return $this->status->val();
+    }
+
+    public function revision(): int
+    {
+        return $this->revision;
+    }
+
+    public function answers(): array
+    {
+        return $this->answers->toArray();
+    }
+
+    public function defaults(): array
+    {
+        return $this->defaults->toArray();
+    }
+
+    public function skipped(): array
+    {
+        return $this->skipped->toArray();
+    }
+
+    public function resolvedAnswers(): array
+    {
+        return Arr::merge($this->defaults->toArray(), $this->answers->toArray());
+    }
+
+    public function unanswered(): array
+    {
+        $answered = Arr::make($this->answers->keys());
+        $skipped = $this->skipped;
+
+        return Arr::make(self::FIELDS)
+            ->filter(static fn (string $field): bool => !$answered->contains($field) && !$skipped->contains($field))
+            ->toArray();
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'session_id' => $this->sessionId(),
+            'tenant_id' => $this->tenantId(),
+            'application_slug' => $this->applicationSlug(),
+            'prompt_version' => $this->promptVersion->val(),
+            'status' => $this->status(),
+            'answers' => $this->answers(),
+            'defaults' => $this->defaults(),
+            'skipped' => $this->skipped(),
+            'unanswered' => $this->unanswered(),
+            'resolved_answers' => $this->resolvedAnswers(),
+            'actor' => $this->actor->toArray(),
+            'correlation_id' => $this->correlationId?->val(),
+            'revision' => $this->revision(),
+            'created_at' => $this->createdAt->val(),
+            'updated_at' => $this->updatedAt->val(),
+            'completed_at' => $this->completedAt?->val(),
+        ];
+    }
+
+    private static function defaultAnswers(): array
+    {
+        return [
+            'project_type' => 'general_web_application',
+            'industry' => 'technology_and_communications',
+            'audience' => 'b2c_consumers',
+            'description' => 'A general platform for professional services and automation through agentic workflows.',
+            'personality' => 'professional_and_informative',
+            'agent_name' => 'Opus',
+        ];
+    }
+
+    private static function normalizeSlug(string $value): string
+    {
+        $slug = Str::make($value)
+            ->trim()
+            ->replace('-', '_')
+            ->snake()
+            ->replace('_', '-')
+            ->val();
+
+        if (Str::isEmpty($slug)) {
+            throw new InvalidArgumentException('application_slug_required');
+        }
+
+        return $slug;
+    }
+
+    private static function now(): string
+    {
+        return Date::now()->format('Y-m-d H:i:s')->val();
+    }
+
+    private function guard(): void
+    {
+        if (Str::isEmpty($this->sessionId->val()) || Str::isEmpty($this->applicationSlug->val())) {
+            throw new InvalidArgumentException('invalid_intake_identity');
+        }
+        if (!Arr::make([self::IN_PROGRESS, self::PAUSED, self::COMPLETED])->contains($this->status())) {
+            throw new InvalidArgumentException('invalid_intake_status');
+        }
+        if (Val::isEmpty($this->answers->toArray()['project_name'] ?? null)) {
+            throw new InvalidArgumentException('project_name_required');
+        }
+    }
+
+    private function guardField(string $field): void
+    {
+        if (!Arr::make(self::FIELDS)->contains($field)) {
+            throw new InvalidArgumentException('unknown_intake_field');
+        }
+    }
+
+    private function revise(
+        ?string $status = null,
+        ?array $answers = null,
+        ?array $skipped = null,
+        array $actor = [],
+        ?string $correlationId = null,
+        ?string $completedAt = null
+    ): self {
+        $nextCompletedAt = $this->completedAt?->val();
+        if ($status === self::COMPLETED) {
+            $nextCompletedAt = $completedAt ?? self::now();
+        } elseif ($status !== null) {
+            $nextCompletedAt = null;
+        }
+
+        return new self(
+            $this->sessionId(),
+            $this->tenantId(),
+            $this->applicationSlug(),
+            $this->promptVersion->val(),
+            $status ?? $this->status(),
+            $answers ?? $this->answers(),
+            $this->defaults(),
+            $skipped ?? $this->skipped(),
+            Arr::isNotEmpty($actor) ? $actor : $this->actor->toArray(),
+            Str::isNotEmpty((string) $correlationId) ? $correlationId : $this->correlationId?->val(),
+            $this->revision + 1,
+            $this->createdAt->val(),
+            self::now(),
+            $nextCompletedAt
+        );
+    }
+}

--- a/app/Domain/Onboarding/IApplicationIntakeRepository.php
+++ b/app/Domain/Onboarding/IApplicationIntakeRepository.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Onboarding;
+
+interface IApplicationIntakeRepository
+{
+    public function find(string $sessionId): ?ApplicationIntakeSession;
+
+    public function save(ApplicationIntakeSession $session): ApplicationIntakeSession;
+}

--- a/app/Domain/Onboarding/Models/ApplicationIntakeModel.php
+++ b/app/Domain/Onboarding/Models/ApplicationIntakeModel.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Onboarding\Models;
+
+use BlueFission\BlueCore\Model\ModelSql;
+
+class ApplicationIntakeModel extends ModelSql
+{
+    protected $_table = 'application_intakes';
+
+    protected $_fields = [
+        'application_intake_id',
+        'session_key',
+        'tenant_id',
+        'application_slug',
+        'prompt_version',
+        'status',
+        'answers',
+        'defaults',
+        'skipped',
+        'actor',
+        'correlation_id',
+        'revision',
+        'session_created_at',
+        'session_updated_at',
+        'completed_at',
+    ];
+
+    protected $_ignore_null = false;
+}

--- a/app/Domain/Onboarding/Models/ApplicationIntakeModel.php
+++ b/app/Domain/Onboarding/Models/ApplicationIntakeModel.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Domain\Onboarding\Models;
 
+use BlueFission\Arr;
 use BlueFission\BlueCore\Model\ModelSql;
+use BlueFission\Val;
 
 class ApplicationIntakeModel extends ModelSql
 {
@@ -29,4 +31,73 @@ class ApplicationIntakeModel extends ModelSql
     ];
 
     protected $_ignore_null = false;
+
+    public function insertIfAbsent(array $record): bool
+    {
+        $columns = $this->persistedColumns($record);
+        $names = Arr::make($columns)
+            ->map(static fn (mixed $value, string $column): string => '`' . $column . '`')
+            ->values()
+            ->join(', ');
+        $values = Arr::make($columns)
+            ->map(fn (mixed $value): string => $this->sqlLiteral($value))
+            ->values()
+            ->join(', ');
+
+        return $this->executeMutation(
+            "INSERT INTO `{$this->_table}` ({$names}) VALUES ({$values}) "
+            . 'ON DUPLICATE KEY UPDATE `session_key` = `session_key`'
+        );
+    }
+
+    public function updateIfRevision(array $record, int $expectedRevision): bool
+    {
+        $columns = $this->persistedColumns($record);
+        $assignments = Arr::make($columns)
+            ->filter(static fn (mixed $value, string $column): bool => $column !== 'session_key')
+            ->map(fn (mixed $value, string $column): string => (
+                '`' . $column . '` = ' . $this->sqlLiteral($value)
+            ))
+            ->values()
+            ->join(', ');
+        $sessionKey = $this->sqlLiteral($columns['session_key']);
+
+        return $this->executeMutation(
+            "UPDATE `{$this->_table}` SET {$assignments} "
+            . "WHERE `session_key` = {$sessionKey} AND `revision` = {$expectedRevision}"
+        );
+    }
+
+    private function persistedColumns(array $record): array
+    {
+        return Arr::make($record)
+            ->filter(fn (mixed $value, string $column): bool => Arr::has($this->_fields, $column))
+            ->toArray();
+    }
+
+    private function executeMutation(string $query): bool
+    {
+        $this->_dataObject->run($query);
+        $this->_dataObject->run('SELECT ROW_COUNT() AS affected_rows');
+        $result = Arr::toArray($this->_dataObject->contents(), true);
+
+        return (int) ($result['affected_rows'] ?? 0) === 1;
+    }
+
+    private function sqlLiteral(mixed $value): string
+    {
+        if (Val::isNull($value)) {
+            return 'NULL';
+        }
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+
+        $hex = bin2hex((string) $value);
+
+        return $hex === '' ? "''" : "CONVERT(0x{$hex} USING utf8mb4)";
+    }
 }

--- a/app/Domain/Onboarding/Repositories/ApplicationIntakeRepositorySql.php
+++ b/app/Domain/Onboarding/Repositories/ApplicationIntakeRepositorySql.php
@@ -8,7 +8,6 @@ use App\Domain\Onboarding\ApplicationIntakeSession;
 use App\Domain\Onboarding\IApplicationIntakeRepository;
 use App\Domain\Onboarding\Models\ApplicationIntakeModel;
 use BlueFission\Arr;
-use BlueFission\Data\Storage\Storage;
 use BlueFission\Net\HTTP;
 use BlueFission\Val;
 use RuntimeException;
@@ -29,10 +28,8 @@ final class ApplicationIntakeRepositorySql implements IApplicationIntakeReposito
 
     public function save(ApplicationIntakeSession $session): ApplicationIntakeSession
     {
-        $existing = $this->findData($session->sessionId());
         $data = $session->toArray();
         $record = [
-            'application_intake_id' => $existing['application_intake_id'] ?? null,
             'session_key' => $session->sessionId(),
             'tenant_id' => $session->tenantId(),
             'application_slug' => $session->applicationSlug(),
@@ -49,12 +46,23 @@ final class ApplicationIntakeRepositorySql implements IApplicationIntakeReposito
             'completed_at' => $data['completed_at'],
         ];
 
-        $this->model->assign($record)->write();
-        if ($this->model->status() !== Storage::STATUS_SUCCESS) {
-            throw new RuntimeException('intake_session_persistence_failed');
+        if ($session->revision() === 1) {
+            if (!$this->model->insertIfAbsent($record)) {
+                throw new RuntimeException('intake_session_already_exists');
+            }
+
+            return $session;
         }
 
-        return $session;
+        if ($this->model->updateIfRevision($record, $session->revision() - 1)) {
+            return $session;
+        }
+
+        if ($this->findData($session->sessionId()) === null && $this->model->insertIfAbsent($record)) {
+            return $session;
+        }
+
+        throw new RuntimeException('intake_session_stale_revision');
     }
 
     private function findData(string $sessionId): ?array

--- a/app/Domain/Onboarding/Repositories/ApplicationIntakeRepositorySql.php
+++ b/app/Domain/Onboarding/Repositories/ApplicationIntakeRepositorySql.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Onboarding\Repositories;
+
+use App\Domain\Onboarding\ApplicationIntakeSession;
+use App\Domain\Onboarding\IApplicationIntakeRepository;
+use App\Domain\Onboarding\Models\ApplicationIntakeModel;
+use BlueFission\Arr;
+use BlueFission\Data\Storage\Storage;
+use BlueFission\Net\HTTP;
+use BlueFission\Val;
+use RuntimeException;
+
+final class ApplicationIntakeRepositorySql implements IApplicationIntakeRepository
+{
+    public function __construct(
+        private ApplicationIntakeModel $model
+    ) {
+    }
+
+    public function find(string $sessionId): ?ApplicationIntakeSession
+    {
+        $data = $this->findData($sessionId);
+
+        return $data === null ? null : $this->hydrate($data);
+    }
+
+    public function save(ApplicationIntakeSession $session): ApplicationIntakeSession
+    {
+        $existing = $this->findData($session->sessionId());
+        $data = $session->toArray();
+        $record = [
+            'application_intake_id' => $existing['application_intake_id'] ?? null,
+            'session_key' => $session->sessionId(),
+            'tenant_id' => $session->tenantId(),
+            'application_slug' => $session->applicationSlug(),
+            'prompt_version' => $data['prompt_version'],
+            'status' => $session->status(),
+            'answers' => HTTP::jsonEncode($session->answers()),
+            'defaults' => HTTP::jsonEncode($session->defaults()),
+            'skipped' => HTTP::jsonEncode($session->skipped()),
+            'actor' => HTTP::jsonEncode($data['actor']),
+            'correlation_id' => $data['correlation_id'],
+            'revision' => $session->revision(),
+            'session_created_at' => $data['created_at'],
+            'session_updated_at' => $data['updated_at'],
+            'completed_at' => $data['completed_at'],
+        ];
+
+        $this->model->assign($record)->write();
+        if ($this->model->status() !== Storage::STATUS_SUCCESS) {
+            throw new RuntimeException('intake_session_persistence_failed');
+        }
+
+        return $session;
+    }
+
+    private function findData(string $sessionId): ?array
+    {
+        $this->model->clear();
+        $this->model->condition('session_key', '=', $sessionId);
+        $this->model->limit(1);
+        $this->model->read();
+        $data = Arr::toArray($this->model->data(), true);
+
+        return Val::isEmpty($data['session_key'] ?? null) ? null : $data;
+    }
+
+    private function hydrate(array $data): ApplicationIntakeSession
+    {
+        return ApplicationIntakeSession::fromArray([
+            'session_id' => $data['session_key'],
+            'tenant_id' => $data['tenant_id'] ?? null,
+            'application_slug' => $data['application_slug'],
+            'prompt_version' => $data['prompt_version'],
+            'status' => $data['status'],
+            'answers' => HTTP::jsonDecode((string) $data['answers'], true, []),
+            'defaults' => HTTP::jsonDecode((string) $data['defaults'], true, []),
+            'skipped' => HTTP::jsonDecode((string) $data['skipped'], true, []),
+            'actor' => HTTP::jsonDecode((string) $data['actor'], true, []),
+            'correlation_id' => $data['correlation_id'] ?? null,
+            'revision' => (int) $data['revision'],
+            'created_at' => $data['session_created_at'],
+            'updated_at' => $data['session_updated_at'],
+            'completed_at' => $data['completed_at'] ?? null,
+        ]);
+    }
+}

--- a/app/Registration/AppRegistration.php
+++ b/app/Registration/AppRegistration.php
@@ -15,6 +15,8 @@ use App\Business\Services\AgentCapabilityMapLoader;
 use App\Business\Services\AgentCapabilityMapResolver;
 use App\Business\Services\AgentContinuationScopeStore;
 use App\Business\Services\AgentScopedCommandProcessor;
+use App\Domain\Onboarding\IApplicationIntakeRepository;
+use App\Domain\Onboarding\Repositories\ApplicationIntakeRepositorySql;
 use BlueFission\Data\Storage\Session;
 use BlueFission\BlueCore\Core;
 use BlueFission\BlueCore\IExtension;
@@ -104,6 +106,7 @@ class AppRegistration implements IExtension {
 		$this->bind('BlueFission\BlueCore\Domain\AddOn\Repositories\IAddOnRepository', 'BlueFission\BlueCore\Domain\AddOn\Repositories\AddOnRepositorySql');
 
 		$this->bind('BlueFission\Data\Storage\Storage', 'BlueFission\Data\Storage\MySQL');
+		$this->bind(IApplicationIntakeRepository::class, ApplicationIntakeRepositorySql::class);
 		$this->bind(ICommandProcessor::class, AgentScopedCommandProcessor::class);
 	}
 

--- a/datasources/structure/20260828_create_application_intakes.php
+++ b/datasources/structure/20260828_create_application_intakes.php
@@ -1,0 +1,36 @@
+<?php
+
+use BlueFission\BlueCore\Datasource\Delta;
+use BlueFission\Data\Storage\Structure\MySQLScaffold as Scaffold;
+use BlueFission\Data\Storage\Structure\MySQLStructure as Structure;
+
+final class CreateApplicationIntakes extends Delta
+{
+    public function change()
+    {
+        Scaffold::create('application_intakes', function (Structure $entity): void {
+            $entity->incrementer('application_intake_id');
+            $entity->text('session_key', 64)->unique();
+            $entity->text('tenant_id', 128)->null();
+            $entity->text('application_slug', 191);
+            $entity->text('prompt_version', 64);
+            $entity->text('status', 32);
+            $entity->text('answers', 65535);
+            $entity->text('defaults', 65535);
+            $entity->text('skipped', 65535);
+            $entity->text('actor', 65535);
+            $entity->text('correlation_id', 191)->null();
+            $entity->numeric('revision', 11)->default(1);
+            $entity->text('session_created_at', 32);
+            $entity->text('session_updated_at', 32);
+            $entity->text('completed_at', 32)->null();
+            $entity->timestamps();
+            $entity->comment('Resumable application and central-agent intake sessions.');
+        });
+    }
+
+    public function revert()
+    {
+        Scaffold::delete('application_intakes');
+    }
+}

--- a/docs/agentic-onboarding.md
+++ b/docs/agentic-onboarding.md
@@ -1,0 +1,24 @@
+# Agentic Onboarding
+
+Opus application onboarding is a resumable intake process, not an execution trigger. Creating, answering, skipping, pausing, resuming, or completing an intake session cannot install add-ons, invoke providers, generate code, publish workflows, or mutate the application beyond the intake record itself.
+
+## Session contract
+
+- Project name is the only required answer.
+- Application slugs are stable within an application or tenant scope.
+- Project and agent display names remain editable independently from the slug.
+- Explicit answers, defaults, skipped fields, and unanswered fields are stored separately.
+- Prompt version, actor, tenant, correlation, revision, and transition timestamps are retained.
+- Completed sessions may be resumed when the operator wants to provide more context.
+
+The initial defaults describe a general technology and communications web application for business-to-consumer audiences, with professional and informative agent behavior. Defaults are resolved for planning but do not masquerade as explicit operator answers.
+
+## Boundaries
+
+`ApplicationIntakeService` owns host-neutral transitions and delegates persistence through `IApplicationIntakeRepository`. The SQL adapter stores normalized session state in `application_intakes`.
+
+Vibe prompt execution, JenSS branching, Wise commands, HTTP/admin presentation, plan generation, marketplace discovery, and workflow execution are separate capabilities. Those layers may consume this contract but must not bypass it or attach side effects to intake transitions.
+
+## Migration
+
+Run the standard database delta command before resolving the SQL repository in a fresh application. Existing applications do not receive an intake session automatically.

--- a/docs/agentic-onboarding.md
+++ b/docs/agentic-onboarding.md
@@ -19,6 +19,13 @@ The initial defaults describe a general technology and communications web applic
 
 Vibe prompt execution, JenSS branching, Wise commands, HTTP/admin presentation, plan generation, marketplace discovery, and workflow execution are separate capabilities. Those layers may consume this contract but must not bypass it or attach side effects to intake transitions.
 
+## Extension points
+
+- `opus.intake.defaults` filters an envelope containing `defaults` and read-only `context`. Only the filtered `defaults` array is consumed; project identity, tenant, slug, and prompt version remain authoritative inputs.
+- `opus.intake.session.transitioned` runs after a successful persistence write with a payload containing `transition` and the normalized `session`. Supported transition values are `started`, `answered`, `skipped`, `paused`, `resumed`, and `completed`.
+
+Idempotent start reads do not emit a transition action. Extensions must handle their own failures; an exception from a post-persistence action does not undo the completed write.
+
 ## Migration
 
 Run the standard database delta command before resolving the SQL repository in a fresh application. Existing applications do not receive an intake session automatically.

--- a/tests/Unit/Business/Services/ApplicationIntakeServiceTest.php
+++ b/tests/Unit/Business/Services/ApplicationIntakeServiceTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Business\Services;
+
+use App\Business\Services\ApplicationIntakeService;
+use App\Domain\Onboarding\ApplicationIntakeSession;
+use App\Domain\Onboarding\IApplicationIntakeRepository;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class ApplicationIntakeServiceTest extends TestCase
+{
+    public function testProjectNameIsTheOnlyRequiredStartingAnswer(): void
+    {
+        $service = new ApplicationIntakeService($this->repository());
+
+        $session = $service->start('Professional Services Hub');
+        $data = $session->toArray();
+
+        $this->assertSame('professional-services-hub', $session->applicationSlug());
+        $this->assertSame(['project_name' => 'Professional Services Hub'], $session->answers());
+        $this->assertSame('Opus', $session->defaults()['agent_name']);
+        $this->assertSame('general_web_application', $session->resolvedAnswers()['project_type']);
+        $this->assertContains('project_type', $data['unanswered']);
+        $this->assertSame(ApplicationIntakeSession::IN_PROGRESS, $session->status());
+    }
+
+    public function testStartIsIdempotentWithinAnApplicationScope(): void
+    {
+        $repository = $this->repository();
+        $service = new ApplicationIntakeService($repository);
+
+        $first = $service->start('Service Desk', 'tenant-a');
+        $second = $service->start('Service Desk', 'tenant-a', actor: ['id' => 'actor-b']);
+        $otherTenant = $service->start('Service Desk', 'tenant-b');
+        $applicationScope = $service->start('Service Desk');
+        $tenantNamedApplication = $service->start('Service Desk', 'application');
+
+        $this->assertSame($first->sessionId(), $second->sessionId());
+        $this->assertNotSame($first->sessionId(), $otherTenant->sessionId());
+        $this->assertNotSame($applicationScope->sessionId(), $tenantNamedApplication->sessionId());
+        $this->assertSame(4, $repository->writes);
+    }
+
+    public function testSlugCollisionsFailClosed(): void
+    {
+        $service = new ApplicationIntakeService($this->repository());
+        $service->start('Service Desk');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('application_slug_conflict');
+        $service->start('Different Project', applicationSlug: 'service-desk');
+    }
+
+    public function testAnswersDefaultsSkipsAndUnansweredFieldsRemainDistinct(): void
+    {
+        $service = new ApplicationIntakeService($this->repository());
+        $session = $service->start('Operations');
+
+        $skipped = $service->skip($session->sessionId(), 'audience');
+        $answered = $service->answer($skipped->sessionId(), 'audience', 'internal_operators');
+
+        $this->assertContains('audience', $skipped->skipped());
+        $this->assertNotContains('audience', $skipped->unanswered());
+        $this->assertSame('b2c_consumers', $skipped->resolvedAnswers()['audience']);
+        $this->assertNotContains('audience', $answered->skipped());
+        $this->assertSame('internal_operators', $answered->answers()['audience']);
+        $this->assertSame('internal_operators', $answered->resolvedAnswers()['audience']);
+    }
+
+    public function testPausedAndCompletedSessionsCanResumeWithoutExecutingWork(): void
+    {
+        $service = new ApplicationIntakeService($this->repository());
+        $session = $service->start('Automation Studio');
+
+        $paused = $service->pause($session->sessionId(), ['id' => 'operator-a'], 'pause-a');
+        $completed = $service->complete($paused->sessionId(), ['id' => 'operator-a'], 'complete-a');
+        $resumed = $service->resume($completed->sessionId(), ['id' => 'operator-b'], 'resume-b');
+
+        $this->assertSame(ApplicationIntakeSession::PAUSED, $paused->status());
+        $this->assertSame(ApplicationIntakeSession::COMPLETED, $completed->status());
+        $this->assertNotNull($completed->toArray()['completed_at']);
+        $this->assertSame(ApplicationIntakeSession::IN_PROGRESS, $resumed->status());
+        $this->assertNull($resumed->toArray()['completed_at']);
+        $this->assertSame('resume-b', $resumed->toArray()['correlation_id']);
+    }
+
+    public function testRequiredAndUnknownFieldsFailClosed(): void
+    {
+        $service = new ApplicationIntakeService($this->repository());
+
+        try {
+            $service->start('   ');
+            $this->fail('A blank project name should be rejected.');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame('project_name_required', $exception->getMessage());
+        }
+
+        $session = $service->start('Knowledge Base');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('unknown_intake_field');
+        $service->answer($session->sessionId(), 'provider_api_key', 'secret');
+    }
+
+    public function testMissingSessionsReturnAStableFailure(): void
+    {
+        $service = new ApplicationIntakeService($this->repository());
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('intake_session_not_found');
+        $service->resume('missing');
+    }
+
+    private function repository(): object
+    {
+        return new class implements IApplicationIntakeRepository {
+            /** @var array<string, ApplicationIntakeSession> */
+            public array $sessions = [];
+            public int $writes = 0;
+
+            public function find(string $sessionId): ?ApplicationIntakeSession
+            {
+                return $this->sessions[$sessionId] ?? null;
+            }
+
+            public function save(ApplicationIntakeSession $session): ApplicationIntakeSession
+            {
+                $this->sessions[$session->sessionId()] = $session;
+                $this->writes++;
+
+                return $session;
+            }
+        };
+    }
+}

--- a/tests/Unit/Business/Services/ApplicationIntakeServiceTest.php
+++ b/tests/Unit/Business/Services/ApplicationIntakeServiceTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Business\Services;
 use App\Business\Services\ApplicationIntakeService;
 use App\Domain\Onboarding\ApplicationIntakeSession;
 use App\Domain\Onboarding\IApplicationIntakeRepository;
+use BlueFission\DevElation;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -150,6 +151,60 @@ final class ApplicationIntakeServiceTest extends TestCase
         }
     }
 
+    public function testDefaultsCanBeFilteredWithoutReplacingAuthoritativeIdentity(): void
+    {
+        $this->withDevElationHooks(function (): void {
+            DevElation::filter('opus.intake.defaults', static function (array $payload): array {
+                $payload['defaults']['agent_name'] = 'Atlas';
+                $payload['context']['project_name'] = 'Replaced';
+                $payload['context']['tenant_id'] = 'tenant-b';
+                $payload['context']['application_slug'] = 'replaced';
+
+                return $payload;
+            });
+
+            $session = (new ApplicationIntakeService($this->repository()))->start(
+                'Service Studio',
+                'tenant-a'
+            );
+
+            $this->assertSame('Atlas', $session->defaults()['agent_name']);
+            $this->assertSame('Service Studio', $session->answers()['project_name']);
+            $this->assertSame('tenant-a', $session->tenantId());
+            $this->assertSame('service-studio', $session->applicationSlug());
+        });
+    }
+
+    public function testPersistedTransitionsPublishOneStableActionPayload(): void
+    {
+        $this->withDevElationHooks(function (): void {
+            $transitions = [];
+            DevElation::action(
+                'opus.intake.session.transitioned',
+                static function (array $payload) use (&$transitions): void {
+                    $transitions[] = $payload;
+                }
+            );
+
+            $service = new ApplicationIntakeService($this->repository());
+            $session = $service->start('Workflow Studio', 'tenant-a');
+            $service->start('Workflow Studio', 'tenant-a');
+            $session = $service->answer($session->sessionId(), 'audience', 'operators');
+            $session = $service->skip($session->sessionId(), 'timeline');
+            $session = $service->pause($session->sessionId());
+            $session = $service->resume($session->sessionId());
+            $service->complete($session->sessionId());
+
+            $this->assertSame(
+                ['started', 'answered', 'skipped', 'paused', 'resumed', 'completed'],
+                array_column($transitions, 'transition')
+            );
+            $this->assertSame('tenant-a', $transitions[0]['session']['tenant_id']);
+            $this->assertSame('workflow-studio', $transitions[5]['session']['application_slug']);
+            $this->assertSame(ApplicationIntakeSession::COMPLETED, $transitions[5]['session']['status']);
+        });
+    }
+
     public function testMissingSessionsReturnAStableFailure(): void
     {
         $service = new ApplicationIntakeService($this->repository());
@@ -179,5 +234,25 @@ final class ApplicationIntakeServiceTest extends TestCase
                 return $session;
             }
         };
+    }
+
+    private function withDevElationHooks(callable $test): void
+    {
+        $reflection = new \ReflectionClass(DevElation::class);
+        $active = $reflection->getProperty('_isActive');
+        $filters = $reflection->getProperty('_filters');
+        $actions = $reflection->getProperty('_actions');
+        $originalActive = $active->getValue();
+        $originalFilters = $filters->getValue();
+        $originalActions = $actions->getValue();
+
+        try {
+            DevElation::up();
+            $test();
+        } finally {
+            $active->setValue(null, $originalActive);
+            $filters->setValue(null, $originalFilters);
+            $actions->setValue(null, $originalActions);
+        }
     }
 }

--- a/tests/Unit/Business/Services/ApplicationIntakeServiceTest.php
+++ b/tests/Unit/Business/Services/ApplicationIntakeServiceTest.php
@@ -55,6 +55,33 @@ final class ApplicationIntakeServiceTest extends TestCase
         $service->start('Different Project', applicationSlug: 'service-desk');
     }
 
+    public function testConcurrentStartsReturnThePersistedSession(): void
+    {
+        $winner = ApplicationIntakeSession::start('Service Desk', 'tenant-a');
+        $repository = new class($winner) implements IApplicationIntakeRepository {
+            private bool $firstSave = true;
+
+            public function __construct(private ApplicationIntakeSession $winner)
+            {
+            }
+
+            public function find(string $sessionId): ?ApplicationIntakeSession
+            {
+                return $this->firstSave ? null : $this->winner;
+            }
+
+            public function save(ApplicationIntakeSession $session): ApplicationIntakeSession
+            {
+                $this->firstSave = false;
+                throw new RuntimeException('intake_session_already_exists');
+            }
+        };
+
+        $session = (new ApplicationIntakeService($repository))->start('Service Desk', 'tenant-a');
+
+        $this->assertSame($winner->toArray(), $session->toArray());
+    }
+
     public function testAnswersDefaultsSkipsAndUnansweredFieldsRemainDistinct(): void
     {
         $service = new ApplicationIntakeService($this->repository());
@@ -103,6 +130,24 @@ final class ApplicationIntakeServiceTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('unknown_intake_field');
         $service->answer($session->sessionId(), 'provider_api_key', 'secret');
+    }
+
+    public function testProjectNameAnswersAreTrimmedStrings(): void
+    {
+        $service = new ApplicationIntakeService($this->repository());
+        $session = $service->start('Knowledge Base');
+
+        $renamed = $service->answer($session->sessionId(), 'project_name', '  Knowledge Studio  ');
+        $this->assertSame('Knowledge Studio', $renamed->answers()['project_name']);
+
+        foreach ([[], ['invalid'], '   '] as $invalidName) {
+            try {
+                $service->answer($session->sessionId(), 'project_name', $invalidName);
+                $this->fail('Project names must be non-empty strings.');
+            } catch (InvalidArgumentException $exception) {
+                $this->assertSame('project_name_required', $exception->getMessage());
+            }
+        }
     }
 
     public function testMissingSessionsReturnAStableFailure(): void

--- a/tests/Unit/Domain/Onboarding/ApplicationIntakeRepositorySqlTest.php
+++ b/tests/Unit/Domain/Onboarding/ApplicationIntakeRepositorySqlTest.php
@@ -44,6 +44,88 @@ final class ApplicationIntakeRepositorySqlTest extends TestCase
         $this->assertSame('resume-b', $resumed->toArray()['correlation_id']);
         $this->assertSame(2, $model->writes);
     }
+
+    public function testItRejectsAStaleRevisionWithoutOverwritingTheWinner(): void
+    {
+        $model = new InMemoryApplicationIntakeModel();
+        $repository = new ApplicationIntakeRepositorySql($model);
+        $session = ApplicationIntakeSession::start('Operations Studio', 'tenant-a');
+        $repository->save($session);
+
+        $first = $repository->find($session->sessionId());
+        $second = $repository->find($session->sessionId());
+        $this->assertNotNull($first);
+        $this->assertNotNull($second);
+
+        $repository->save($first->answer('timeline', 'discovery'));
+
+        try {
+            $repository->save($second->answer('timeline', 'production'));
+            $this->fail('A stale revision must not overwrite the committed answer.');
+        } catch (\RuntimeException $exception) {
+            $this->assertSame('intake_session_stale_revision', $exception->getMessage());
+        }
+
+        $stored = $repository->find($session->sessionId());
+        $this->assertNotNull($stored);
+        $this->assertSame('discovery', $stored->answers()['timeline']);
+        $this->assertSame(2, $stored->revision());
+    }
+
+    public function testModelMutationsUseAtomicInsertAndRevisionGuards(): void
+    {
+        $storage = new RecordingMutationStorage([1, 0]);
+        $model = new RecordingApplicationIntakeModel($storage);
+        $record = [
+            'session_key' => 'session-a',
+            'status' => ApplicationIntakeSession::IN_PROGRESS,
+            'revision' => 5,
+        ];
+
+        $this->assertTrue($model->insertIfAbsent($record));
+        $this->assertFalse($model->updateIfRevision($record, 4));
+        $this->assertStringContainsString('ON DUPLICATE KEY UPDATE', $storage->queries[0]);
+        $this->assertSame('SELECT ROW_COUNT() AS affected_rows', $storage->queries[1]);
+        $this->assertStringContainsString('AND `revision` = 4', $storage->queries[2]);
+        $this->assertSame('SELECT ROW_COUNT() AS affected_rows', $storage->queries[3]);
+    }
+}
+
+final class RecordingApplicationIntakeModel extends ApplicationIntakeModel
+{
+    public function __construct(RecordingMutationStorage $storage)
+    {
+        $this->_dataObject = $storage;
+    }
+}
+
+final class RecordingMutationStorage
+{
+    /** @var list<string> */
+    public array $queries = [];
+
+    private array $affectedRows;
+    private array $contents = [];
+
+    public function __construct(array $affectedRows)
+    {
+        $this->affectedRows = $affectedRows;
+    }
+
+    public function run(string $query): self
+    {
+        $this->queries[] = $query;
+        if ($query === 'SELECT ROW_COUNT() AS affected_rows') {
+            $this->contents = ['affected_rows' => array_shift($this->affectedRows)];
+        }
+
+        return $this;
+    }
+
+    public function contents(): array
+    {
+        return $this->contents;
+    }
 }
 
 final class InMemoryApplicationIntakeModel extends ApplicationIntakeModel
@@ -96,16 +178,28 @@ final class InMemoryApplicationIntakeModel extends ApplicationIntakeModel
         return $this;
     }
 
-    public function write($values = null): Obj
+    public function insertIfAbsent(array $record): bool
     {
-        if ($values !== null) {
-            $this->working = (array) $values;
+        if ($this->record !== []) {
+            return false;
         }
 
-        $this->record = $this->working;
+        $this->record = $record;
         $this->writes++;
 
-        return $this;
+        return true;
+    }
+
+    public function updateIfRevision(array $record, int $expectedRevision): bool
+    {
+        if ((int) ($this->record['revision'] ?? 0) !== $expectedRevision) {
+            return false;
+        }
+
+        $this->record = array_merge($this->record, $record);
+        $this->writes++;
+
+        return true;
     }
 
     public function status($message = null): mixed

--- a/tests/Unit/Domain/Onboarding/ApplicationIntakeRepositorySqlTest.php
+++ b/tests/Unit/Domain/Onboarding/ApplicationIntakeRepositorySqlTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Onboarding;
+
+use App\Domain\Onboarding\ApplicationIntakeSession;
+use App\Domain\Onboarding\Models\ApplicationIntakeModel;
+use App\Domain\Onboarding\Repositories\ApplicationIntakeRepositorySql;
+use BlueFission\Data\Storage\Storage;
+use BlueFission\Obj;
+use PHPUnit\Framework\TestCase;
+
+final class ApplicationIntakeRepositorySqlTest extends TestCase
+{
+    public function testItPersistsAndHydratesAResumableSession(): void
+    {
+        $model = new InMemoryApplicationIntakeModel();
+        $repository = new ApplicationIntakeRepositorySql($model);
+        $session = ApplicationIntakeSession::start(
+            'Operations Studio',
+            'tenant-a',
+            actor: ['id' => 'operator-a'],
+            correlationId: 'start-a'
+        );
+        $session = $session
+            ->answer('timeline', 'phased')
+            ->skip('audience')
+            ->complete(['id' => 'operator-a'], 'complete-a');
+
+        $repository->save($session);
+        $loaded = $repository->find($session->sessionId());
+
+        $this->assertNotNull($loaded);
+        $this->assertSame($session->toArray(), $loaded->toArray());
+        $this->assertSame(1, $model->writes);
+
+        $repository->save($loaded->resume(['id' => 'operator-b'], 'resume-b'));
+        $resumed = $repository->find($session->sessionId());
+
+        $this->assertNotNull($resumed);
+        $this->assertSame(ApplicationIntakeSession::IN_PROGRESS, $resumed->status());
+        $this->assertNull($resumed->toArray()['completed_at']);
+        $this->assertSame('resume-b', $resumed->toArray()['correlation_id']);
+        $this->assertSame(2, $model->writes);
+    }
+}
+
+final class InMemoryApplicationIntakeModel extends ApplicationIntakeModel
+{
+    public int $writes = 0;
+
+    private array $record = [];
+    private array $working = [];
+    private mixed $conditionValue = null;
+
+    public function __construct()
+    {
+    }
+
+    public function clear(): Obj
+    {
+        $this->working = [];
+
+        return $this;
+    }
+
+    public function condition($field, $condition = '', $value = ''): void
+    {
+        $this->conditionValue = $value;
+    }
+
+    public function limit($limit): self
+    {
+        return $this;
+    }
+
+    public function read($values = null): Obj
+    {
+        $this->working = ($this->record['session_key'] ?? null) === $this->conditionValue
+            ? $this->record
+            : [];
+
+        return $this;
+    }
+
+    public function data(): mixed
+    {
+        return $this->working;
+    }
+
+    public function assign($data): Obj
+    {
+        $this->working = (array) $data;
+
+        return $this;
+    }
+
+    public function write($values = null): Obj
+    {
+        if ($values !== null) {
+            $this->working = (array) $values;
+        }
+
+        $this->record = $this->working;
+        $this->writes++;
+
+        return $this;
+    }
+
+    public function status($message = null): mixed
+    {
+        return Storage::STATUS_SUCCESS;
+    }
+}

--- a/tests/Unit/Registration/AppRegistrationTest.php
+++ b/tests/Unit/Registration/AppRegistrationTest.php
@@ -6,6 +6,8 @@ namespace Tests\Unit\Registration;
 
 use App\Business\Services\VibeThemeRenderer;
 use App\Business\Services\AgentScopedCommandProcessor;
+use App\Domain\Onboarding\IApplicationIntakeRepository;
+use App\Domain\Onboarding\Repositories\ApplicationIntakeRepositorySql;
 use App\Registration\AppRegistration;
 use BlueFission\BlueCore\Theme;
 use BlueFission\Str;
@@ -57,6 +59,10 @@ final class AppRegistrationTest extends TestCase
         $this->assertSame(
             AgentScopedCommandProcessor::class,
             $app->bindings[ICommandProcessor::class]
+        );
+        $this->assertSame(
+            ApplicationIntakeRepositorySql::class,
+            $app->bindings[IApplicationIntakeRepository::class]
         );
     }
 


### PR DESCRIPTION
## Intent

Add a host-neutral, resumable application intake contract for central-agent onboarding without attaching workflow execution, provider calls, package installation, or code generation to intake transitions.

Closes #96. Advances #29 and #95.

## User stories and acceptance criteria

- An operator can start an intake session with only a project name.
- An operator can answer, skip, pause, complete, and later resume the same session.
- Explicit answers, defaults, skipped prompts, and unanswered prompts remain distinguishable.
- The application slug is immutable and deterministic within application or tenant scope.
- Actor, tenant, correlation, prompt version, revision, and timestamps survive persistence.
- Slug collisions fail closed.
- Intake operations have no execution side effects.

## Key files

- `ApplicationIntakeSession` defines immutable transitions and defaults.
- `ApplicationIntakeService` provides the host-neutral application boundary.
- `IApplicationIntakeRepository` and `ApplicationIntakeRepositorySql` provide persistence without coupling presentation to storage.
- `20260828_create_application_intakes.php` creates the database record shape.
- `docs/agentic-onboarding.md` documents ownership and deferred capabilities.

## Validation

```text
php vendor/phpunit/phpunit/phpunit --do-not-cache-result tests/Unit/Business/Services/ApplicationIntakeServiceTest.php
OK (7 tests, 29 assertions)

php vendor/phpunit/phpunit/phpunit --do-not-cache-result tests/Unit/Domain/Onboarding/ApplicationIntakeRepositorySqlTest.php
OK (1 test, 8 assertions)

php vendor/phpunit/phpunit/phpunit --do-not-cache-result tests/Unit/Registration/AppRegistrationTest.php
OK (3 tests, 10 assertions)

php vendor/phpunit/phpunit/phpunit --do-not-cache-result
OK (328 tests, 1436 assertions, 11 expected skips)
```

PHP syntax validation and `git diff --check` pass. The full suite retains the existing Windows hard-link diagnostic from the Vibe generation test.

## QA checklist

- [x] Only project name is required.
- [x] Application and tenant scopes cannot collide.
- [x] Start is idempotent for the same scoped project.
- [x] Explicit slug conflicts fail closed.
- [x] Completed sessions can resume and clear completion state.
- [x] SQL serialization round-trips defaults, skips, actors, and correlations.
- [x] Repository registration resolves through the application container.
- [x] No provider, workflow, package, or generation service is invoked.

## Migration and approval conditions

- Run the standard database delta before resolving the SQL repository in an existing installation.
- Review the immutable slug and default-value vocabulary as public application contracts.
- Confirm the persistence record shape before Vibe/JenSS prompts and interface adapters build on it.

This PR deliberately excludes prompt rendering, command exposure, admin UI, plan generation, discovery, and execution policy. Those remain separate priority slices under #95.
