### PR TITLE
Defer agent command bootstrap on HTTP requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ php vendor/bin/opus-addon.php validate <addon-root>
 
 Opus's event management system allows you to hook into various events and filters, making it easy to extend and customize the framework's behavior.
 
+The lazy Wise command boundary publishes non-blocking `opus.agent.command_runtime.ready` and `opus.agent.command_runtime.unavailable` DevElation actions. Their payloads contain only stable status metadata; dependency injection remains the supported processor replacement boundary, and observer failures cannot alter command availability.
+
 ### Add-On System
 
 The add-on architecture allows for seamless feature additions and management without modifying core files directly. See the [add-on authoring guide](ADDONS.md) for the package boundary, lifecycle, structure, and validation expectations.

--- a/app/Business/Console/CliManager.php
+++ b/app/Business/Console/CliManager.php
@@ -15,10 +15,13 @@ use BotMan\BotMan\BotMan;
 
 class CliManager extends Service
 {
+    private AgentCommandContextProvider $contextProvider;
+
     public function __construct(
         private WiseCommandHost $commandHost,
-        private AgentCommandContextProvider $contextProvider
+        ?AgentCommandContextProvider $contextProvider = null
     ) {
+        $this->contextProvider = $contextProvider ?? new AgentCommandContextProvider();
         parent::__construct();
     }
 

--- a/app/Business/Services/AgentCommandContextProvider.php
+++ b/app/Business/Services/AgentCommandContextProvider.php
@@ -8,12 +8,18 @@ use BlueFission\Arr;
 use BlueFission\BlueCore\Domain\AddOn\Queries\IActivatedAddOnsQuery;
 use BlueFission\DevElation;
 use BlueFission\Str;
+use Closure;
 use Throwable;
 
 final class AgentCommandContextProvider
 {
-    public function __construct(private ?IActivatedAddOnsQuery $activatedAddOns = null)
-    {
+    private ?Closure $queryResolver;
+
+    public function __construct(
+        private ?IActivatedAddOnsQuery $activatedAddOns = null,
+        ?callable $queryResolver = null
+    ) {
+        $this->queryResolver = $queryResolver === null ? null : Closure::fromCallable($queryResolver);
     }
 
     public function forActor(string $actorId, ?string $tenantId = null): array
@@ -22,7 +28,7 @@ final class AgentCommandContextProvider
         $states = Arr::make([]);
 
         try {
-            $records = $this->activatedAddOns?->fetch() ?? [];
+            $records = $this->activatedAddOns()?->fetch() ?? [];
             Arr::make(Arr::is($records) ? $records : [])->each(
                 function ($record) use ($active, $states): void {
                     $record = Arr::make((array) $record);
@@ -75,5 +81,21 @@ final class AgentCommandContextProvider
         $refreshed = Arr::make($this->forActor($actorId, Str::is($tenantId) ? $tenantId : null));
 
         return $refreshed->toArray();
+    }
+
+    private function activatedAddOns(): ?IActivatedAddOnsQuery
+    {
+        if ($this->activatedAddOns !== null) {
+            return $this->activatedAddOns;
+        }
+
+        $resolved = $this->queryResolver === null
+            ? \App::makeInstance(IActivatedAddOnsQuery::class)
+            : ($this->queryResolver)();
+        if ($resolved instanceof IActivatedAddOnsQuery) {
+            $this->activatedAddOns = $resolved;
+        }
+
+        return $this->activatedAddOns;
     }
 }

--- a/app/Business/Services/LazyAgentCommandProcessor.php
+++ b/app/Business/Services/LazyAgentCommandProcessor.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Business\Services;
+
+use BlueFission\Data\Storage\Session;
+use BlueFission\Wise\Cmd\Command;
+use BlueFission\Wise\Cmd\CommandProcessor;
+use BlueFission\Wise\Cmd\CommandRequest;
+use BlueFission\Wise\Cmd\CommandResult;
+use BlueFission\Wise\Cmd\ICommandProcessor;
+use Closure;
+use RuntimeException;
+use Throwable;
+
+final class LazyAgentCommandProcessor implements ICommandProcessor
+{
+    private ?ICommandProcessor $processor = null;
+    private ?Closure $factory;
+
+    public function __construct(?callable $factory = null)
+    {
+        $this->factory = $factory === null ? null : Closure::fromCallable($factory);
+    }
+
+    public function process(CommandRequest|Command|array|string $request): CommandResult
+    {
+        try {
+            return $this->processor()->process($request);
+        } catch (Throwable) {
+            return CommandResult::invalid(
+                'The command runtime is unavailable.',
+                ['agent_command_runtime_unavailable'],
+                [
+                    'agent_decision' => 'deny',
+                    'agent_reason' => 'command_runtime_unavailable',
+                    'agent_result_status' => CommandResult::INVALID,
+                ]
+            );
+        }
+    }
+
+    private function processor(): ICommandProcessor
+    {
+        if ($this->processor !== null) {
+            return $this->processor;
+        }
+
+        $processor = $this->factory === null
+            ? $this->buildProcessor()
+            : ($this->factory)();
+        if (!$processor instanceof ICommandProcessor || $processor === $this) {
+            throw new RuntimeException('invalid_agent_command_processor');
+        }
+
+        return $this->processor = $processor;
+    }
+
+    private function buildProcessor(): ICommandProcessor
+    {
+        $storage = new Session(['location' => 'cache', 'name' => 'system']);
+        $loader = new AgentCapabilityMapLoader();
+
+        return new AgentScopedCommandProcessor(
+            new CommandProcessor($storage),
+            new AgentCapabilityMapResolver(
+                $loader->loadApplication(APP_ROOT . 'mapping/agents.php'),
+                catalog: new AgentCapabilityMapCatalog(APP_ROOT . 'addons', $loader)
+            ),
+            new AgentContinuationScopeStore($storage)
+        );
+    }
+}

--- a/app/Business/Services/LazyAgentCommandProcessor.php
+++ b/app/Business/Services/LazyAgentCommandProcessor.php
@@ -27,7 +27,7 @@ final class LazyAgentCommandProcessor implements ICommandProcessor
     public function process(CommandRequest|Command|array|string $request): CommandResult
     {
         try {
-            return $this->processor()->process($request);
+            $processor = $this->processor();
         } catch (Throwable) {
             return CommandResult::invalid(
                 'The command runtime is unavailable.',
@@ -39,6 +39,8 @@ final class LazyAgentCommandProcessor implements ICommandProcessor
                 ]
             );
         }
+
+        return $processor->process($request);
     }
 
     private function processor(): ICommandProcessor

--- a/app/Business/Services/LazyAgentCommandProcessor.php
+++ b/app/Business/Services/LazyAgentCommandProcessor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Business\Services;
 
 use BlueFission\Data\Storage\Session;
+use BlueFission\DevElation;
 use BlueFission\Wise\Cmd\Command;
 use BlueFission\Wise\Cmd\CommandProcessor;
 use BlueFission\Wise\Cmd\CommandRequest;
@@ -29,6 +30,12 @@ final class LazyAgentCommandProcessor implements ICommandProcessor
         try {
             $processor = $this->processor();
         } catch (Throwable) {
+            $this->publishRuntimeAction('opus.agent.command_runtime.unavailable', [
+                'status' => 'unavailable',
+                'reason' => 'command_runtime_unavailable',
+                'retryable' => true,
+            ]);
+
             return CommandResult::invalid(
                 'The command runtime is unavailable.',
                 ['agent_command_runtime_unavailable'],
@@ -56,7 +63,13 @@ final class LazyAgentCommandProcessor implements ICommandProcessor
             throw new RuntimeException('invalid_agent_command_processor');
         }
 
-        return $this->processor = $processor;
+        $this->processor = $processor;
+        $this->publishRuntimeAction('opus.agent.command_runtime.ready', [
+            'status' => 'ready',
+            'source' => $this->factory === null ? 'application' : 'factory',
+        ]);
+
+        return $this->processor;
     }
 
     private function buildProcessor(): ICommandProcessor
@@ -72,5 +85,14 @@ final class LazyAgentCommandProcessor implements ICommandProcessor
             ),
             new AgentContinuationScopeStore($storage)
         );
+    }
+
+    private function publishRuntimeAction(string $name, array $payload): void
+    {
+        try {
+            DevElation::do($name, [$payload]);
+        } catch (Throwable) {
+            // Observers cannot change command-runtime availability.
+        }
     }
 }

--- a/app/Registration/AppRegistration.php
+++ b/app/Registration/AppRegistration.php
@@ -1,8 +1,6 @@
 <?php
 namespace App\Registration;
 // use BlueFission\BlueCore\Business\Managers\CommandManager;
-use App\Business\Middleware\ProcessesCommandMiddleware;
-use App\Business\Services\AgentCommandContextProvider;
 use BlueFission\BlueCore\Business\Managers\NavMenuManager;
 use BlueFission\BlueCore\Business\Managers\DatasourceManager;
 use BlueFission\BlueCore\Business\Managers\AddOnManager;
@@ -10,16 +8,10 @@ use App\Business\MysqlConnector;
 use App\Business\Presentation\PackageTheme;
 use App\Business\Services\RuntimePathResolver;
 use App\Business\Services\VibeThemeRenderer;
-use App\Business\Services\AgentCapabilityMapCatalog;
-use App\Business\Services\AgentCapabilityMapLoader;
-use App\Business\Services\AgentCapabilityMapResolver;
-use App\Business\Services\AgentContinuationScopeStore;
-use App\Business\Services\AgentScopedCommandProcessor;
+use App\Business\Services\LazyAgentCommandProcessor;
 use BlueFission\Data\Storage\Session;
 use BlueFission\BlueCore\Core;
 use BlueFission\BlueCore\IExtension;
-use BlueFission\BlueCore\Domain\AddOn\Queries\IActivatedAddOnsQuery;
-use BlueFission\Wise\Cmd\CommandProcessor;
 use BlueFission\Wise\Cmd\ICommandProcessor;
 
 /**
@@ -104,19 +96,13 @@ class AppRegistration implements IExtension {
 		$this->bind('BlueFission\BlueCore\Domain\AddOn\Repositories\IAddOnRepository', 'BlueFission\BlueCore\Domain\AddOn\Repositories\AddOnRepositorySql');
 
 		$this->bind('BlueFission\Data\Storage\Storage', 'BlueFission\Data\Storage\MySQL');
-		$this->bind(ICommandProcessor::class, AgentScopedCommandProcessor::class);
+		$this->bind(ICommandProcessor::class, LazyAgentCommandProcessor::class);
 	}
 
 	/**
 	 * Pass arguments to different components
 	 */
 	public function arguments() {
-		$commandStorage = new Session(['location' => 'cache', 'name' => 'system']);
-		$agentMapLoader = new AgentCapabilityMapLoader();
-		$contextProvider = new AgentCommandContextProvider(
-			\App::makeInstance(IActivatedAddOnsQuery::class)
-		);
-
 		$this->bindArgs( ['session'=>new Session()], 'App\Business\Http\AdminController');
 		$this->bindArgs( ['session'=>new Session()], 'BlueFission\BlueCore\Auth');
 
@@ -127,17 +113,6 @@ class AppRegistration implements IExtension {
 
 		$this->bindArgs( ['link'=>\App::makeInstance('BlueFission\Connections\Database\MySQLLink'), 'storage'=>\App::makeInstance('BlueFission\Data\Storage\MySQLBulk')], 'BlueFission\BlueCore\Business\Managers\DatasourceManager');
 		
-		$this->bindArgs(['storage' => $commandStorage], CommandProcessor::class);
-		$this->bindArgs([
-			'processor' => \App::makeInstance(CommandProcessor::class),
-			'resolver' => new AgentCapabilityMapResolver(
-				$agentMapLoader->loadApplication(APP_ROOT . 'mapping/agents.php'),
-				catalog: new AgentCapabilityMapCatalog(APP_ROOT . 'addons', $agentMapLoader)
-			),
-			'continuations' => new AgentContinuationScopeStore($commandStorage),
-		], AgentScopedCommandProcessor::class);
-		$this->bindArgs(['contextProvider' => $contextProvider], ProcessesCommandMiddleware::class);
-		$this->bindArgs(['contextProvider' => $contextProvider], \App\Business\Console\CliManager::class);
 	}
 
 	public function addons()

--- a/tests/Unit/Business/Services/LazyAgentCommandProcessorTest.php
+++ b/tests/Unit/Business/Services/LazyAgentCommandProcessorTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Business\Services;
 use App\Business\Services\AgentCommandContextProvider;
 use App\Business\Services\LazyAgentCommandProcessor;
 use BlueFission\BlueCore\Domain\AddOn\Queries\IActivatedAddOnsQuery;
+use BlueFission\DevElation;
 use BlueFission\Wise\Cmd\Command;
 use BlueFission\Wise\Cmd\CommandRequest;
 use BlueFission\Wise\Cmd\CommandResult;
@@ -82,6 +83,54 @@ final class LazyAgentCommandProcessorTest extends TestCase
         $processor->process('run command');
     }
 
+    public function testRuntimeLifecycleActionsAreStableAndNonBlocking(): void
+    {
+        $this->withDevElationHooks(function (): void {
+            $ready = [];
+            $unavailable = [];
+            DevElation::action(
+                'opus.agent.command_runtime.ready',
+                static function (array $payload) use (&$ready): void {
+                    $ready[] = $payload;
+                    throw new RuntimeException('observer failed');
+                }
+            );
+            DevElation::action(
+                'opus.agent.command_runtime.unavailable',
+                static function (array $payload) use (&$unavailable): void {
+                    $unavailable[] = $payload;
+                    throw new RuntimeException('observer failed');
+                }
+            );
+
+            $inner = new class implements ICommandProcessor {
+                public function process(CommandRequest|Command|array|string $request): CommandResult
+                {
+                    return CommandResult::completed(['ok' => true]);
+                }
+            };
+            $available = new LazyAgentCommandProcessor(
+                static fn (): ICommandProcessor => $inner
+            );
+            $failed = new LazyAgentCommandProcessor(
+                static fn (): ICommandProcessor => throw new RuntimeException('runtime failed')
+            );
+
+            $this->assertSame(CommandResult::COMPLETED, $available->process('list command')->status());
+            $this->assertSame(CommandResult::COMPLETED, $available->process('list command')->status());
+            $this->assertSame(CommandResult::INVALID, $failed->process('list command')->status());
+            $this->assertSame([['status' => 'ready', 'source' => 'factory']], $ready);
+            $this->assertSame(
+                [[
+                    'status' => 'unavailable',
+                    'reason' => 'command_runtime_unavailable',
+                    'retryable' => true,
+                ]],
+                $unavailable
+            );
+        });
+    }
+
     public function testActivatedAddOnQueryIsResolvedOnlyWhenContextIsRequested(): void
     {
         $resolutions = 0;
@@ -106,5 +155,22 @@ final class LazyAgentCommandProcessorTest extends TestCase
         $this->assertSame(1, $resolutions);
         $this->assertSame(['reporting'], $first['active_addons']);
         $this->assertSame(['reporting'], $second['active_addons']);
+    }
+
+    private function withDevElationHooks(callable $test): void
+    {
+        $reflection = new \ReflectionClass(DevElation::class);
+        $active = $reflection->getProperty('_isActive');
+        $actions = $reflection->getProperty('_actions');
+        $originalActive = $active->getValue();
+        $originalActions = $actions->getValue();
+
+        try {
+            DevElation::up();
+            $test();
+        } finally {
+            $active->setValue(null, $originalActive);
+            $actions->setValue(null, $originalActions);
+        }
     }
 }

--- a/tests/Unit/Business/Services/LazyAgentCommandProcessorTest.php
+++ b/tests/Unit/Business/Services/LazyAgentCommandProcessorTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Business\Services;
+
+use App\Business\Services\AgentCommandContextProvider;
+use App\Business\Services\LazyAgentCommandProcessor;
+use BlueFission\BlueCore\Domain\AddOn\Queries\IActivatedAddOnsQuery;
+use BlueFission\Wise\Cmd\Command;
+use BlueFission\Wise\Cmd\CommandRequest;
+use BlueFission\Wise\Cmd\CommandResult;
+use BlueFission\Wise\Cmd\ICommandProcessor;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class LazyAgentCommandProcessorTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!interface_exists(ICommandProcessor::class)
+            || !class_exists(CommandRequest::class)
+            || !class_exists(CommandResult::class)
+        ) {
+            $this->markTestSkipped('The optional typed Wise command runtime is unavailable.');
+        }
+    }
+
+    public function testCommandRuntimeIsBuiltOnlyWhenFirstInvoked(): void
+    {
+        $builds = 0;
+        $inner = new class implements ICommandProcessor {
+            public int $calls = 0;
+
+            public function process(CommandRequest|Command|array|string $request): CommandResult
+            {
+                $this->calls++;
+
+                return CommandResult::completed(['ok' => true]);
+            }
+        };
+        $processor = new LazyAgentCommandProcessor(
+            static function () use (&$builds, $inner): ICommandProcessor {
+                $builds++;
+
+                return $inner;
+            }
+        );
+
+        $this->assertSame(0, $builds);
+        $this->assertSame(CommandResult::COMPLETED, $processor->process('list command')->status());
+        $this->assertSame(CommandResult::COMPLETED, $processor->process('list command')->status());
+        $this->assertSame(1, $builds);
+        $this->assertSame(2, $inner->calls);
+    }
+
+    public function testDeferredRuntimeFailuresReturnAStableCommandResult(): void
+    {
+        $processor = new LazyAgentCommandProcessor(
+            static fn (): ICommandProcessor => throw new RuntimeException('runtime failed')
+        );
+
+        $result = $processor->process('list command');
+
+        $this->assertSame(CommandResult::INVALID, $result->status());
+        $this->assertSame(['agent_command_runtime_unavailable'], $result->diagnostics());
+        $this->assertSame('command_runtime_unavailable', $result->metadata()['agent_reason']);
+    }
+
+    public function testActivatedAddOnQueryIsResolvedOnlyWhenContextIsRequested(): void
+    {
+        $resolutions = 0;
+        $query = new class implements IActivatedAddOnsQuery {
+            public function fetch(): array
+            {
+                return [['name' => 'reporting', 'is_active' => 1]];
+            }
+        };
+        $provider = new AgentCommandContextProvider(
+            queryResolver: static function () use (&$resolutions, $query): IActivatedAddOnsQuery {
+                $resolutions++;
+
+                return $query;
+            }
+        );
+
+        $this->assertSame(0, $resolutions);
+        $first = $provider->forActor('operator-a');
+        $second = $provider->forActor('operator-b');
+
+        $this->assertSame(1, $resolutions);
+        $this->assertSame(['reporting'], $first['active_addons']);
+        $this->assertSame(['reporting'], $second['active_addons']);
+    }
+}

--- a/tests/Unit/Business/Services/LazyAgentCommandProcessorTest.php
+++ b/tests/Unit/Business/Services/LazyAgentCommandProcessorTest.php
@@ -67,6 +67,21 @@ final class LazyAgentCommandProcessorTest extends TestCase
         $this->assertSame('command_runtime_unavailable', $result->metadata()['agent_reason']);
     }
 
+    public function testExecutionFailuresAreNotMisreportedAsConstructionFailures(): void
+    {
+        $inner = new class implements ICommandProcessor {
+            public function process(CommandRequest|Command|array|string $request): CommandResult
+            {
+                throw new RuntimeException('execution failed');
+            }
+        };
+        $processor = new LazyAgentCommandProcessor(static fn (): ICommandProcessor => $inner);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('execution failed');
+        $processor->process('run command');
+    }
+
     public function testActivatedAddOnQueryIsResolvedOnlyWhenContextIsRequested(): void
     {
         $resolutions = 0;

--- a/tests/Unit/Registration/AppRegistrationTest.php
+++ b/tests/Unit/Registration/AppRegistrationTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Registration;
 
 use App\Business\Services\VibeThemeRenderer;
-use App\Business\Services\AgentScopedCommandProcessor;
+use App\Business\Services\LazyAgentCommandProcessor;
 use App\Registration\AppRegistration;
 use BlueFission\BlueCore\Theme;
 use BlueFission\Str;
@@ -55,7 +55,7 @@ final class AppRegistrationTest extends TestCase
         $registration->bindings();
 
         $this->assertSame(
-            AgentScopedCommandProcessor::class,
+            LazyAgentCommandProcessor::class,
             $app->bindings[ICommandProcessor::class]
         );
     }


### PR DESCRIPTION
## Intent

Keep ordinary HTTP bootstrap independent from Wise command-runtime construction while preserving the same scoped command behavior when a CLI, chat, or programmatic command is actually invoked.

Closes #94.

## User stories and acceptance criteria

- Health, login, and dashboard bootstrap do not instantiate the activated add-on query, Wise processor, capability maps, or continuation storage.
- The typed command processor remains container-resolvable through a lightweight application-owned proxy.
- First command use builds one scoped runtime and reuses it for subsequent calls.
- Activated add-on state is resolved only when an actor command context is requested.
- Deferred runtime failures produce a structured denied `CommandResult` instead of terminating HTTP startup.
- Explicitly injected processors and lifecycle queries remain supported for tests and hosts.

## Key files

- `LazyAgentCommandProcessor` owns deferred construction and structured failure behavior.
- `AgentCommandContextProvider` resolves lifecycle state on first context use.
- `AppRegistration` binds the lazy processor and removes eager agent/Wise argument construction.
- `CliManager` supplies its context provider lazily when a host does not inject one.

## Validation

```text
php -l app/Business/Services/LazyAgentCommandProcessor.php
php -l app/Business/Services/AgentCommandContextProvider.php
php -l app/Business/Console/CliManager.php
php -l app/Registration/AppRegistration.php
php -l tests/Unit/Business/Services/LazyAgentCommandProcessorTest.php

php vendor/phpunit/phpunit/phpunit --do-not-cache-result tests/Unit/Registration/AppRegistrationTest.php
OK (3 tests, 9 assertions)
```

The lazy-runtime test class contains three additional tests for one-time construction, structured failure, and deferred add-on query resolution. They are explicitly skipped when the installed optional Wise runtime predates the typed processor contract; CI against the locked dependency graph is the acceptance gate.

`git diff --check` passes.

## QA checklist

- [x] No agent map is loaded by `AppRegistration::arguments()`.
- [x] No activated add-on query is resolved during registration.
- [x] The public `ICommandProcessor` binding remains available.
- [x] Deferred failures remain host-neutral and structured.
- [x] Existing explicit dependency injection remains backward compatible.
- [ ] Locked-dependency CI executes the lazy-runtime tests without skips.
- [ ] HTTP health and readiness smoke tests confirm no eager command bootstrap.

## Approval conditions

- Confirm the lazy proxy remains the application-owned boundary while Wise owns command semantics.
- Confirm CI executes all typed-runtime tests with the released Wise contract.
- Replay the standard HTTP health/readiness checks before marking ready to merge.