### PR TITLE
Consume released Wise alpha

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         "symfony/http-client": "^7.3"
     },
     "require-dev": {
-        "bluefission/wise": "0.1.0-alpha.1",
+        "bluefission/wise": "0.1.0-alpha.2",
         "phpunit/phpunit": "^9.5"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "bluefission/develation": "^1.3.43",
         "bluefission/opus-addon-hoom": "dev-main",
         "bluefission/opus-addon-kapsle": "dev-main",
-        "bluefission/presence": "dev-main",
+        "bluefission/presence": "0.1.0-alpha.3",
         "bluefission/simpleclients": "^0.1.0@alpha",
         "bluefission/synematic": "dev-main",
         "bluefission/synthetiq": "^0.1.0@alpha",
@@ -68,7 +68,7 @@
         "symfony/http-client": "^7.3"
     },
     "require-dev": {
-        "bluefission/wise": "dev-main",
+        "bluefission/wise": "0.1.0-alpha.1",
         "phpunit/phpunit": "^9.5"
     },
     "suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "546c5e8b9a436cfa2997cfef4faff62c",
+    "content-hash": "d84280a1afb0423897909e4feb5a8edc",
     "packages": [
         {
             "name": "bluefission/annex-php-sdk",
@@ -3154,16 +3154,16 @@
         },
         {
             "name": "bluefission/wise",
-            "version": "v0.1.0-alpha.1",
+            "version": "v0.1.0-alpha.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bluefissiontech/wise",
-                "reference": "b751e48212278e1dfec3f2492577eefb9eb1a71c"
+                "reference": "e55c68fd690c529989ccce62c74f2fe62e00edef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bluefissiontech/wise/zipball/b751e48212278e1dfec3f2492577eefb9eb1a71c",
-                "reference": "b751e48212278e1dfec3f2492577eefb9eb1a71c",
+                "url": "https://api.github.com/repos/bluefissiontech/wise/zipball/e55c68fd690c529989ccce62c74f2fe62e00edef",
+                "reference": "e55c68fd690c529989ccce62c74f2fe62e00edef",
                 "shasum": ""
             },
             "require": {
@@ -3231,7 +3231,7 @@
                 "llm",
                 "shell"
             ],
-            "time": "2026-09-01T20:01:19+00:00"
+            "time": "2026-09-01T22:16:44+00:00"
         },
         {
             "name": "brick/math",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7278a0aa90fc26a37954eab2971d7950",
+    "content-hash": "546c5e8b9a436cfa2997cfef4faff62c",
     "packages": [
         {
             "name": "bluefission/annex-php-sdk",
@@ -52,16 +52,16 @@
         },
         {
             "name": "bluefission/automata",
-            "version": "v1.0.0-alpha.3",
+            "version": "v1.0.0-alpha.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/BlueFissionTech/automata.git",
-                "reference": "c48adfd13bcf4bddd66dfd0fee77c5d5430b52f0"
+                "reference": "b3e3e1e7e1238a2df48d630f0d1f896aef279511"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/BlueFissionTech/automata/zipball/c48adfd13bcf4bddd66dfd0fee77c5d5430b52f0",
-                "reference": "c48adfd13bcf4bddd66dfd0fee77c5d5430b52f0",
+                "url": "https://api.github.com/repos/BlueFissionTech/automata/zipball/b3e3e1e7e1238a2df48d630f0d1f896aef279511",
+                "reference": "b3e3e1e7e1238a2df48d630f0d1f896aef279511",
                 "shasum": ""
             },
             "require": {
@@ -71,7 +71,7 @@
                 "php-ai/php-ml": "^0.10.0"
             },
             "require-dev": {
-                "bluefission/simpleclients": "dev-master",
+                "bluefission/simpleclients": "^0.1.0-alpha",
                 "phpunit/phpunit": "^11.5"
             },
             "suggest": {
@@ -119,7 +119,7 @@
                 "issues": "https://github.com/BlueFissionTech/automata/issues",
                 "source": "https://github.com/BlueFissionTech/automata"
             },
-            "time": "2026-08-08T21:14:46+00:00"
+            "time": "2026-08-31T21:39:54+00:00"
         },
         {
             "name": "bluefission/bluecore",
@@ -432,16 +432,16 @@
         },
         {
             "name": "bluefission/presence",
-            "version": "dev-main",
+            "version": "v0.1.0-alpha.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bluefissiontech/presence",
-                "reference": "9637482818b6ff2ed3c18b012d94545e649a12c2"
+                "reference": "5c01dca824a2bccb2c899b59ab9587d21b715515"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bluefissiontech/presence/zipball/9637482818b6ff2ed3c18b012d94545e649a12c2",
-                "reference": "9637482818b6ff2ed3c18b012d94545e649a12c2",
+                "url": "https://api.github.com/repos/bluefissiontech/presence/zipball/5c01dca824a2bccb2c899b59ab9587d21b715515",
+                "reference": "5c01dca824a2bccb2c899b59ab9587d21b715515",
                 "shasum": ""
             },
             "require": {
@@ -459,7 +459,6 @@
                 "bluefission/bluecore": "Adds framework bridge and middleware hosting capabilities.",
                 "bluefission/synematic": "Adds workflow, provenance, privacy, and interoperability coordination."
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -501,7 +500,7 @@
                 "maps",
                 "session"
             ],
-            "time": "2026-08-09T00:59:17+00:00"
+            "time": "2026-09-01T15:38:47+00:00"
         },
         {
             "name": "bluefission/simpleclients",
@@ -3119,7 +3118,7 @@
     "packages-dev": [
         {
             "name": "bluefission/jenerator",
-            "version": "dev-main",
+            "version": "v0.1.0-alpha.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bluefissiontech/jenerator",
@@ -3139,7 +3138,6 @@
             "require-dev": {
                 "phpunit/phpunit": "^10.5"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -3156,36 +3154,33 @@
         },
         {
             "name": "bluefission/wise",
-            "version": "dev-main",
+            "version": "v0.1.0-alpha.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bluefissiontech/wise",
-                "reference": "ad14e76f9e51ef44b6fd165b1d83a56069722a2a"
+                "reference": "b751e48212278e1dfec3f2492577eefb9eb1a71c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bluefissiontech/wise/zipball/ad14e76f9e51ef44b6fd165b1d83a56069722a2a",
-                "reference": "ad14e76f9e51ef44b6fd165b1d83a56069722a2a",
+                "url": "https://api.github.com/repos/bluefissiontech/wise/zipball/b751e48212278e1dfec3f2492577eefb9eb1a71c",
+                "reference": "b751e48212278e1dfec3f2492577eefb9eb1a71c",
                 "shasum": ""
             },
             "require": {
-                "bluefission/automata": "^1.0.0-alpha.2",
-                "bluefission/develation": "^1.3.42",
-                "bluefission/jenerator": "dev-main",
+                "bluefission/automata": "^1.0.0-alpha.5",
+                "bluefission/develation": "~1.3.43.0",
+                "bluefission/jenerator": "^0.1.0-alpha.1",
+                "bluefission/presence": "0.1.0-alpha.3",
                 "bluefission/simpleclients": "^0.1.0-alpha",
                 "bluefission/synthetiq": "^0.1.0-alpha.1",
                 "bluefission/vibrato": "dev-main",
                 "google/cloud-language": "^0.27.0",
-                "orhanerday/open-ai": "^2.2"
+                "orhanerday/open-ai": "^2.2",
+                "php": ">=8.2"
             },
             "require-dev": {
-                "php": ">=8.0.0",
                 "phpunit/phpunit": "^11.1@dev"
             },
-            "suggest": {
-                "bluefission/presence": "Enables advanced authentication, authorization, and session integration."
-            },
-            "default-branch": true,
             "type": "package",
             "autoload": {
                 "psr-4": {
@@ -3236,7 +3231,7 @@
                 "llm",
                 "shell"
             ],
-            "time": "2026-08-22T21:57:37+00:00"
+            "time": "2026-09-01T20:01:19+00:00"
         },
         {
             "name": "brick/math",
@@ -6376,12 +6371,10 @@
         "bluefission/bluecore": 15,
         "bluefission/opus-addon-hoom": 20,
         "bluefission/opus-addon-kapsle": 20,
-        "bluefission/presence": 20,
         "bluefission/simpleclients": 15,
         "bluefission/synematic": 20,
         "bluefission/synthetiq": 15,
-        "bluefission/vibrato": 20,
-        "bluefission/wise": 20
+        "bluefission/vibrato": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/templates/composer/opus-root.json
+++ b/templates/composer/opus-root.json
@@ -43,7 +43,7 @@
     "require": {
         "php": "^8.2",
         "bluefission/opus": "dev-main",
-        "bluefission/wise": "0.1.0-alpha.1"
+        "bluefission/wise": "0.1.0-alpha.2"
     },
     "config": {
         "use-github-api": false,

--- a/templates/composer/opus-root.json
+++ b/templates/composer/opus-root.json
@@ -43,7 +43,7 @@
     "require": {
         "php": "^8.2",
         "bluefission/opus": "dev-main",
-        "bluefission/wise": "dev-main"
+        "bluefission/wise": "0.1.0-alpha.1"
     },
     "config": {
         "use-github-api": false,

--- a/tests/Unit/ComposerMetadataTest.php
+++ b/tests/Unit/ComposerMetadataTest.php
@@ -32,10 +32,10 @@ class ComposerMetadataTest extends TestCase
         $optional = $this->readJson($root . '/templates/composer/opus-root-optional-wise.json');
 
         $this->assertArrayNotHasKey('bluefission/wise', $composer['require'] ?? []);
-        $this->assertSame('0.1.0-alpha.1', $composer['require-dev']['bluefission/wise'] ?? null);
+        $this->assertSame('0.1.0-alpha.2', $composer['require-dev']['bluefission/wise'] ?? null);
         $this->assertSame('0.1.0-alpha.3', $composer['require']['bluefission/presence'] ?? null);
         $this->assertArrayHasKey('bluefission/wise', $composer['suggest'] ?? []);
-        $this->assertSame('0.1.0-alpha.1', $required['require']['bluefission/wise'] ?? null);
+        $this->assertSame('0.1.0-alpha.2', $required['require']['bluefission/wise'] ?? null);
         $this->assertArrayNotHasKey('bluefission/wise', $optional['require'] ?? []);
         $this->assertArrayNotHasKey('bluefission/wise', $optional['repositories'] ?? []);
     }
@@ -66,9 +66,9 @@ class ComposerMetadataTest extends TestCase
 
         $this->assertInstanceOf(Arr::class, $wise);
         $this->assertInstanceOf(Arr::class, $presence);
-        $this->assertSame('v0.1.0-alpha.1', $wise->get('version'));
+        $this->assertSame('v0.1.0-alpha.2', $wise->get('version'));
         $this->assertSame(
-            'b751e48212278e1dfec3f2492577eefb9eb1a71c',
+            'e55c68fd690c529989ccce62c74f2fe62e00edef',
             $wise->getPath('source.reference')
         );
         $this->assertSame('v0.1.0-alpha.3', $presence->get('version'));

--- a/tests/Unit/ComposerMetadataTest.php
+++ b/tests/Unit/ComposerMetadataTest.php
@@ -63,18 +63,24 @@ class ComposerMetadataTest extends TestCase
 
         $wise = $byName->get('bluefission/wise');
         $presence = $byName->get('bluefission/presence');
+        $wiseReference = 'e55c68fd690c529989ccce62c74f2fe62e00edef';
+        $presenceReference = '5c01dca824a2bccb2c899b59ab9587d21b715515';
 
         $this->assertInstanceOf(Arr::class, $wise);
         $this->assertInstanceOf(Arr::class, $presence);
         $this->assertSame('v0.1.0-alpha.2', $wise->get('version'));
+        $this->assertSame($wiseReference, $wise->getPath('source.reference'));
+        $this->assertSame($wiseReference, $wise->getPath('dist.reference'));
         $this->assertSame(
-            'e55c68fd690c529989ccce62c74f2fe62e00edef',
-            $wise->getPath('source.reference')
+            "https://api.github.com/repos/bluefissiontech/wise/zipball/{$wiseReference}",
+            $wise->getPath('dist.url')
         );
         $this->assertSame('v0.1.0-alpha.3', $presence->get('version'));
+        $this->assertSame($presenceReference, $presence->getPath('source.reference'));
+        $this->assertSame($presenceReference, $presence->getPath('dist.reference'));
         $this->assertSame(
-            '5c01dca824a2bccb2c899b59ab9587d21b715515',
-            $presence->getPath('source.reference')
+            "https://api.github.com/repos/bluefissiontech/presence/zipball/{$presenceReference}",
+            $presence->getPath('dist.url')
         );
     }
 

--- a/tests/Unit/ComposerMetadataTest.php
+++ b/tests/Unit/ComposerMetadataTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit;
 
+use BlueFission\Arr;
 use BlueFission\Data\FileSystem;
 use BlueFission\Net\HTTP;
 use PHPUnit\Framework\TestCase;
@@ -31,9 +32,10 @@ class ComposerMetadataTest extends TestCase
         $optional = $this->readJson($root . '/templates/composer/opus-root-optional-wise.json');
 
         $this->assertArrayNotHasKey('bluefission/wise', $composer['require'] ?? []);
-        $this->assertSame('dev-main', $composer['require-dev']['bluefission/wise'] ?? null);
+        $this->assertSame('0.1.0-alpha.1', $composer['require-dev']['bluefission/wise'] ?? null);
+        $this->assertSame('0.1.0-alpha.3', $composer['require']['bluefission/presence'] ?? null);
         $this->assertArrayHasKey('bluefission/wise', $composer['suggest'] ?? []);
-        $this->assertSame('dev-main', $required['require']['bluefission/wise'] ?? null);
+        $this->assertSame('0.1.0-alpha.1', $required['require']['bluefission/wise'] ?? null);
         $this->assertArrayNotHasKey('bluefission/wise', $optional['require'] ?? []);
         $this->assertArrayNotHasKey('bluefission/wise', $optional['repositories'] ?? []);
     }
@@ -46,6 +48,34 @@ class ComposerMetadataTest extends TestCase
 
         $this->assertNotContains('bluefission/wise', $packages);
         $this->assertContains('bluefission/wise', $developmentPackages);
+    }
+
+    public function testWiseAndPresenceLocksUseReviewedAlphaReleases(): void
+    {
+        $lock = $this->readJson(dirname(__DIR__, 2) . '/composer.lock');
+        $packages = Arr::make($lock['packages'] ?? [])->merge($lock['packages-dev'] ?? []);
+        $byName = Arr::make();
+
+        foreach ($packages as $package) {
+            $package = Arr::make($package);
+            $byName->set((string) $package->get('name'), $package);
+        }
+
+        $wise = $byName->get('bluefission/wise');
+        $presence = $byName->get('bluefission/presence');
+
+        $this->assertInstanceOf(Arr::class, $wise);
+        $this->assertInstanceOf(Arr::class, $presence);
+        $this->assertSame('v0.1.0-alpha.1', $wise->get('version'));
+        $this->assertSame(
+            'b751e48212278e1dfec3f2492577eefb9eb1a71c',
+            $wise->getPath('source.reference')
+        );
+        $this->assertSame('v0.1.0-alpha.3', $presence->get('version'));
+        $this->assertSame(
+            '5c01dca824a2bccb2c899b59ab9587d21b715515',
+            $presence->getPath('source.reference')
+        );
     }
 
     public function testAddOnCommandIsPublishedAsAComposerBinary(): void


### PR DESCRIPTION
## Intent

Consume the reviewed Wise and Presence alpha releases in Opus and its generated required-Wise consumer profile through the canonical authenticated VCS repositories, without introducing Packagist assumptions, unreleased branch pins, or unrelated dependency upgrades.

Advances #56.

## User stories and acceptance criteria

- Opus resolves Wise through the authenticated VCS release `v0.1.0-alpha.2` at `e55c68fd690c529989ccce62c74f2fe62e00edef`.
- Presence resolves through `v0.1.0-alpha.3` at `5c01dca824a2bccb2c899b59ab9587d21b715515`.
- Wise's released Automata and Jenerator floors resolve through their tagged alpha releases.
- Root and generated required-Wise manifests declare the Wise, Jenerator, Vibrato, and Presence VCS repositories, development stability policy, and required Composer plugin authorization.
- The generated required-Wise consumer manifest uses the released Wise constraint.
- Composer metadata tests fail if Wise or Presence drift back to an unreleased branch or unexpected source commit.
- Existing unrelated package versions, including Guzzle 7, remain unchanged.

## Key files changed

- `composer.json`: replace Wise and Presence development constraints with reviewed VCS alpha releases.
- `composer.lock`: lock Wise, Presence, Automata, and Jenerator to the compatible released graph.
- `templates/composer/opus-root.json`: use the released Wise constraint in the authenticated-VCS consumer profile.
- `tests/Unit/ComposerMetadataTest.php`: enforce released constraints and exact lock provenance using DevElation collections.

## Migration notes

No application API migration is required. Consumers regenerating the required-Wise root profile receive `bluefission/wise: 0.1.0-alpha.2`. Wise remains an authenticated VCS dependency and is not expected from Packagist while its private/development dependency graph remains registry-incomplete. Runtime and `ICommandProcessor` contracts are unchanged from alpha.1.

Upstream evidence: [Wise release](https://github.com/BlueFissionTech/wise/releases/tag/v0.1.0-alpha.2) and [PHP 8.2/8.3 package plus empty-consumer run](https://github.com/BlueFissionTech/wise/actions/runs/33565891942).

## How to test

```text
composer install --no-interaction --no-scripts --no-plugins
vendor/bin/phpunit --do-not-cache-result tests/Unit/ComposerMetadataTest.php
vendor/bin/phpunit --do-not-cache-result tests/Unit/Business/Services/WiseIntegrationGuardTest.php tests/Unit/Business/Services/WiseCommandHostTest.php tests/Unit/Business/Services/WiseProfilePolicyResolverTest.php tests/Unit/Business/Services/WiseResourceClassResolverTest.php
vendor/bin/phpunit --do-not-cache-result
composer check-platform-reqs
composer audit
composer run audit:composer-vcs
composer validate --strict
git diff --check
```

Results: 5 focused Composer tests / 33 assertions; 4 Wise integration tests / 7 assertions; 368 full tests / 1,607 assertions with 11 expected skips; platform checks, security audit, recursive 14-package source audit, and diff checks pass. Strict Composer validation reports only the existing non-SPDX `Exclusive` license warning. The full suite also emits the existing Windows `link(): Improper link` shutdown diagnostic after PHPUnit succeeds.

## QA checklist

- [x] Wise is sourced from its canonical VCS repository, not Packagist.
- [x] Only the intended first-party lock entries changed.
- [x] No unreleased Wise or Presence branch constraint remains in the required profiles.
- [x] No unrelated Guzzle or Google dependency upgrade was retained.
- [x] Exact release versions and source SHAs are regression-tested.
- [x] Full application and Wise integration coverage pass.
- [x] Security and source provenance audits pass.

## Approval conditions

- Confirm the authenticated-VCS Wise constraint and exact source provenance.
- Confirm the bounded lock delta.
- Confirm the generated consumer's VCS repository and Composer plugin policy.
- Require fresh exact-head review and green protected checks before landing.